### PR TITLE
Performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - Fix a bug where Windows junctions can cause an infinite loop
 - Fix a minor display bug so ANSI color codes are only sent if the output is a terminal
+- Add a persistent SQLite reverse-geocoding cache so `--locate` can reuse resolved GPS coordinates across inventories and avoid repeated Nominatim requests
+- Run ExifTool batches through configurable parallel worker threads with `--workers` (default: 4)
+- Speed up safe image metadata extraction by using ExifTool `-fast2` for JPEG/PNG/WebP batches
+- Add `--min-image-size` to skip ExifTool for tiny JPG/JPEG/PNG/WebP files that rarely contain useful EXIF, while still indexing them with filesystem metadata
+- Fail scans when ExifTool worker startup or shutdown fails instead of silently treating unavailable or stuck workers as successful blank metadata extraction
 
 ## v1.5.1 (2026-04-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.5.2 (2026-05-03)
+
+- Fix a bug where Windows junctions can cause an infinite loop
+- Fix a minor display bug so ANSI color codes are only sent if the output is a terminal
+
 ## v1.5.1 (2026-04-15)
 
 - Made sure it works well in both Windows and Linux. On my WSL system, it works a whole lot faster when running in Windows vs. a drive mounted via WSL.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # findphotodates.py
 
-**Version 1.5.2 (2026-05-03)** — Alan Rockefeller
+**Version 1.5.2 (2026-05-04)** — Alan Rockefeller
 
 A filesystem inventory tool that indexes all files and extracts EXIF dates and GPS from media files.
 
@@ -38,13 +38,17 @@ A filesystem inventory tool that indexes all files and extracts EXIF dates and G
 - **Cross-platform cache reuse** - Inventories created under WSL get cache hits when re-read from native Windows and vice versa, including transparent normalization for "funny characters" (like quotes) that are represented differently.
 - Saves progress every 15 minutes and handles errors from disconnecting drives gracefully. Picks up where it left off.
 - **Batched ExifTool** - Queries multiple files per ExifTool round-trip for faster metadata extraction on large scans
+- **Parallel ExifTool workers** - Runs batched metadata extraction across configurable worker threads (`--workers`, default 4)
+- **Fast ExifTool path for small safe images** - Uses `-fast2` for JPEG/PNG/WebP batches and skips tiny JPEG/PNG/WebP files below `--min-image-size` unless disabled
 - **Fast directory walking** - Uses `os.scandir()` instead of `os.walk()` for faster file discovery
+- **Persistent location cache** - Reverse-geocoded GPS coordinates are cached in SQLite and shared across inventories
 - **Detailed timing breakdown** - Shows where time is actually spent (discovery, exiftool, stat, hashing, etc.)
 
 ## Requirements
 
 - Python 3.x
 - **ExifTool** must be installed and available on your system PATH. Run `exiftool -ver` to verify. This applies on Linux, macOS, WSL, **and** native Windows.
+- Scans that need ExifTool fail fast if the `exiftool` command cannot be started, rather than writing blank EXIF/date fields for every media file.
 - (Optional) `blake3` library for significantly faster hashing (`pip install blake3`)
 - (Optional) `exifread` library for `check_photo_backups.py` JPEG date reading (`pip install exifread`)
 
@@ -153,7 +157,10 @@ usage: findphotodates.py [-h] [--directory DIRECTORY] [-o OUTPUT] [-q] [--debug]
                         [--sample-chunks INT] [--sample-chunk-mib FLOAT]
                         [--hash-algo {blake3,blake2b,sha256}]
                         [--hash-cache PATH] [--no-hash-cache] [--hash-exts LIST]
-                        [--old-format] [--linux] [--windows] [--save] [--scan]
+                        [--location-cache PATH] [--no-location-cache]
+                        [--old-format] [--debugperformance] [--workers N]
+                        [--min-image-size BYTES] [--linux] [--windows]
+                        [--save] [--scan]
 ```
 
 | Option                    | Description                                                           |
@@ -175,7 +182,12 @@ usage: findphotodates.py [-h] [--directory DIRECTORY] [-o OUTPUT] [-q] [--debug]
 | `--hash-cache`            | Path to SQLite hash cache                                             |
 | `--no-hash-cache`         | Disable hash cache                                                    |
 | `--hash-exts`             | Comma-separated extensions to hash (default: hash all)                |
+| `--location-cache`        | Path to SQLite reverse-geocoding cache                                |
+| `--no-location-cache`     | Disable persistent reverse-geocoding cache                            |
 | `--old-format`            | Write legacy output (`./path: YYYY:MM:DD`) without hashes             |
+| `--debugperformance`      | Print detailed timing statistics after each scan                      |
+| `--workers`               | Number of parallel ExifTool worker threads (default: 4)               |
+| `--min-image-size`        | Skip ExifTool for tiny JPG/JPEG/PNG/WebP files (default: 100,000)     |
 | `--linux`                 | Force Linux-style paths (/mnt/c/...) in output (default: auto-detect) |
 | `--windows`               | Force Windows-style paths (C:\...) in output (default: auto-detect)   |
 | `--save`                  | Save current scan configuration for later use with --scan             |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # findphotodates.py
 
-**Version 1.5.1 (2026-05-03)** — Alan Rockefeller
+**Version 1.5.2 (2026-05-03)** — Alan Rockefeller
 
 A filesystem inventory tool that indexes all files and extracts EXIF dates and GPS from media files.
 

--- a/findphotodates.py
+++ b/findphotodates.py
@@ -85,6 +85,12 @@ EXIFTOOL_EXTENSIONS = (
 # that could carry EXIF dates or GPS).  Matches EXIFTOOL_EXTENSIONS.
 MEDIA_EXTENSIONS = EXIFTOOL_EXTENSIONS
 
+# Images smaller than this threshold are unlikely to carry meaningful EXIF
+# (DateTimeOriginal etc.) and are typically icons, thumbnails, or UI assets.
+# They get indexed with filesystem metadata only, skipping ExifTool entirely.
+MIN_EXIFTOOL_IMAGE_BYTES = 100_000  # 100 KB
+SIZE_FILTERED_IMAGE_EXTENSIONS = frozenset({"jpg", "jpeg", "png", "webp"})
+
 # Backward-compatible alias used by saved scan configs from v1.4
 DEFAULT_EXTENSIONS = PHOTO_EXTENSIONS | VIDEO_EXTENSIONS
 
@@ -885,7 +891,7 @@ def find_files(directory, extensions, debug=False):
 
 
 EXIFTOOL_BATCH_SIZE = (
-    50  # files per exiftool -json batch; tune up for NAS, down for slow disks
+    250  # files per exiftool -json batch; tune up for NAS, down for slow disks
 )
 
 
@@ -1029,8 +1035,12 @@ class ExifToolPersistent:
             return None, None, None
         return self._parse_lines(lines)
 
-    def batch_query(self, filepaths):
+    def batch_query(self, filepaths, fast2=False):
         """Query multiple files at once using -json output.
+
+        If fast2 is True, passes -fast2 to ExifTool, which skips MakerNotes
+        and trailing metadata. Safe for JPEG/PNG/WebP. UNSAFE for RAW formats
+        that store DateTimeOriginal in MakerNotes (e.g. older Nikon bodies).
 
         Returns dict mapping filepath -> (date, gps_lat, gps_lon).
         Files that fail to parse get (None, None, None).
@@ -1043,7 +1053,11 @@ class ExifToolPersistent:
         if not filepaths:
             return {}
 
-        args = ["-json", "-n", "-f", *self._TAGS, *filepaths]
+        args = ["-json", "-n", "-f"]
+        if fast2:
+            args.append("-fast2")
+        args.extend(self._TAGS)
+        args.extend(filepaths)
         lines = self._send_and_read(args)
 
         retries = 3
@@ -1054,7 +1068,8 @@ class ExifToolPersistent:
 
         results = {fp: (None, None, None) for fp in filepaths}
         if lines is None:
-            # Fallback: query one at a time
+            # Fallback: query one at a time. query() intentionally full-parses;
+            # this rare path prefers correctness over preserving fast2.
             for fp in filepaths:
                 results[fp] = self.query(fp)
             return results
@@ -1064,7 +1079,8 @@ class ExifToolPersistent:
         try:
             records = json.loads(json_text)
         except (json.JSONDecodeError, ValueError):
-            # Fallback: query one at a time
+            # Fallback: query one at a time. query() intentionally full-parses;
+            # this rare path prefers correctness over preserving fast2.
             for fp in filepaths:
                 results[fp] = self.query(fp)
             return results
@@ -2212,6 +2228,13 @@ def _clamp_worker_count(workers):
         return 4
 
 
+def _clamp_min_image_size(min_image_size):
+    try:
+        return max(0, int(min_image_size))
+    except (TypeError, ValueError):
+        return MIN_EXIFTOOL_IMAGE_BYTES
+
+
 def _log_worker_error(error_log, error_log_lock, message):
     with error_log_lock:
         error_log.write(message + "\n")
@@ -2316,9 +2339,22 @@ def _exiftool_worker(
                 if exiftool is None:
                     exiftool = ExifToolPersistent()
                     exiftool.start()
-                os_paths = [item[1] for item in batch]
+                fast2_batch = [
+                    item for item in batch if item[5] in SIZE_FILTERED_IMAGE_EXTENSIONS
+                ]
+                full_batch = [
+                    item
+                    for item in batch
+                    if item[5] not in SIZE_FILTERED_IMAGE_EXTENSIONS
+                ]
                 _te0 = time.time()
-                batch_results = exiftool.batch_query(os_paths)
+                batch_results = {}
+                if fast2_batch:
+                    fast2_paths = [item[1] for item in fast2_batch]
+                    batch_results.update(exiftool.batch_query(fast2_paths, fast2=True))
+                if full_batch:
+                    full_paths = [item[1] for item in full_batch]
+                    batch_results.update(exiftool.batch_query(full_paths, fast2=False))
                 t_exiftool = time.time() - _te0
                 worker_stats["t_exiftool"] += t_exiftool
                 if batch_results is None:
@@ -2395,6 +2431,7 @@ def run_scan(
     path_style="linux",  # safe internal default; CLI default is "auto" (resolved before calling)
     raw_output=None,  # Alan 5/3/26 - original CLI --output arg, used only for friendly Windows path hints
     workers=4,
+    min_image_size=MIN_EXIFTOOL_IMAGE_BYTES,
 ):
     """Run a scan on the specified directory.
 
@@ -2402,6 +2439,7 @@ def run_scan(
     """
     _t0 = time.time()
     worker_count = _clamp_worker_count(workers)
+    min_image_size = _clamp_min_image_size(min_image_size)
 
     # Resolve "auto" path style once, before any writes.
     if path_style == "auto":
@@ -2686,6 +2724,34 @@ def run_scan(
             processed_count += len(rows)
             _t_hashing_total += stats["t_hashing"]
 
+        def _index_as_non_media(out_path, fs_path, key_path, size_bytes, mtime_ns, ext):
+            nonlocal processed_count, _t_hashing_total
+            _th0 = time.time()
+            content_hash = get_content_hash(
+                key_path,
+                size_bytes,
+                mtime_ns,
+                hash_options,
+                hash_conn,
+                hash_cache_pending,
+                os_path=fs_path,
+            )
+            _t_hashing_total += time.time() - _th0
+            photo_data.append(
+                (
+                    out_path,
+                    "",
+                    size_bytes,
+                    mtime_ns,
+                    "",
+                    "",
+                    "",
+                    content_hash,
+                )
+            )
+            processed_count += 1
+            file_counts[ext] += 1
+
         def _enqueue_exiftool_batch():
             if not exiftool_batch:
                 return True
@@ -2856,8 +2922,15 @@ def run_scan(
                     else:
                         # Not cached — check if exiftool-eligible
                         if ext in EXIFTOOL_EXTENSIONS:
-                            exiftool_batch.append(
-                                (
+                            # Tiny images (icons, thumbnails) almost never have EXIF.
+                            # RAW/video/other EXIFTOOL_EXTENSIONS are not filtered.
+                            skip_for_size = (
+                                min_image_size > 0
+                                and ext in SIZE_FILTERED_IMAGE_EXTENSIONS
+                                and size_bytes < min_image_size
+                            )
+                            if skip_for_size:
+                                _index_as_non_media(
                                     out_path,
                                     fs_path,
                                     key_path,
@@ -2865,39 +2938,32 @@ def run_scan(
                                     mtime_ns,
                                     ext,
                                 )
-                            )
-                            if len(exiftool_batch) >= EXIFTOOL_BATCH_SIZE:
-                                if not _enqueue_exiftool_batch():
-                                    _stop_workers(interrupt=True)
-                                    cleanup_all()
-                                    return False
+                            else:
+                                exiftool_batch.append(
+                                    (
+                                        out_path,
+                                        fs_path,
+                                        key_path,
+                                        size_bytes,
+                                        mtime_ns,
+                                        ext,
+                                    )
+                                )
+                                if len(exiftool_batch) >= EXIFTOOL_BATCH_SIZE:
+                                    if not _enqueue_exiftool_batch():
+                                        _stop_workers(interrupt=True)
+                                        cleanup_all()
+                                        return False
                         else:
                             # Non-media file: index with filesystem metadata only
-                            _th0 = time.time()
-                            content_hash = get_content_hash(
+                            _index_as_non_media(
+                                out_path,
+                                fs_path,
                                 key_path,
                                 size_bytes,
                                 mtime_ns,
-                                hash_options,
-                                hash_conn,
-                                hash_cache_pending,
-                                os_path=fs_path,
+                                ext,
                             )
-                            _t_hashing_total += time.time() - _th0
-                            photo_data.append(
-                                (
-                                    out_path,
-                                    "",
-                                    size_bytes,
-                                    mtime_ns,
-                                    "",
-                                    "",
-                                    "",
-                                    content_hash,
-                                )
-                            )
-                            processed_count += 1
-                            file_counts[ext] += 1
                     if (
                         cached_entry
                         and cached_entry["size_bytes"] == size_bytes
@@ -3483,6 +3549,7 @@ Options:
   --hash-cache PATH        Path to SQLite hash cache.
   --no-hash-cache          Disable hash cache.
   --workers N       Number of parallel ExifTool workers (default: 4).
+  --min-image-size BYTES  Skip ExifTool for tiny JPG/JPEG/PNG/WebP images (default: 100,000; 0 disables).
   --add-hashes             Fill in missing hashes for an existing inventory file.
   --old-format       Write legacy line-based output (./path: YYYY:MM:DD HH:MM:SS) without hashes.
   --save             Save the current scan configuration for later use.
@@ -3612,6 +3679,18 @@ For more details on a specific option, you can also use:
         help="Number of parallel ExifTool worker processes (default: 4).",
     )
     parser.add_argument(
+        "--min-image-size",
+        type=int,
+        default=MIN_EXIFTOOL_IMAGE_BYTES,
+        metavar="BYTES",
+        help=(
+            f"Skip ExifTool for {'/'.join(sorted(SIZE_FILTERED_IMAGE_EXTENSIONS))} "
+            f"images smaller than this size in bytes (default: {MIN_EXIFTOOL_IMAGE_BYTES:,}). "
+            "Such files are still indexed with filesystem metadata. "
+            "Set to 0 to disable the filter."
+        ),
+    )
+    parser.add_argument(
         "--linux",
         action="store_const",
         dest="path_style",
@@ -3712,6 +3791,7 @@ For more details on a specific option, you can also use:
             "old_format": args.old_format,
             "path_style": args.path_style,
             "workers": _clamp_worker_count(args.workers),
+            "min_image_size": _clamp_min_image_size(args.min_image_size),
         }
 
         config = load_config()
@@ -3779,6 +3859,7 @@ For more details on a specific option, you can also use:
                 path_style=args.path_style,
                 raw_output=output,
                 workers=args.workers,
+                min_image_size=args.min_image_size,
             )
             if scan_perf and (
                 # Print a performance summary if the run takes more than 1000 seconds
@@ -3841,6 +3922,9 @@ For more details on a specific option, you can also use:
                     perf_stats=scan_perf,
                     path_style=flags.get("path_style", "auto"),
                     workers=flags.get("workers", 4),
+                    min_image_size=flags.get(
+                        "min_image_size", MIN_EXIFTOOL_IMAGE_BYTES
+                    ),
                 )
                 if ok is False:
                     any_scan_failed = True
@@ -3889,6 +3973,7 @@ For more details on a specific option, you can also use:
         path_style=args.path_style,
         raw_output=output,
         workers=args.workers,
+        min_image_size=args.min_image_size,
     )
     if scan_perf and (args.debugperformance or scan_perf.get("wall_total", 0) >= 1000):
         _print_perf_summary(directory_abs, scan_perf)

--- a/findphotodates.py
+++ b/findphotodates.py
@@ -101,10 +101,31 @@ TSV_COLUMNS = [
     "content_hash",
 ]
 
-# Default hash cache path
-DEFAULT_HASH_CACHE_DIR = Path.home() / ".cache" / "findphotodates"
-DEFAULT_HASH_CACHE_PATH = DEFAULT_HASH_CACHE_DIR / "hash_cache.sqlite"
+# Default cache paths
+def _default_cache_dir():
+    """Return the per-user cache directory for findphotodates.
+
+    Linux/macOS/WSL: $XDG_CACHE_HOME/findphotodates if set, else ~/.cache/findphotodates
+    Windows: %LOCALAPPDATA%\\findphotodates\\Cache
+    """
+    if platform.system() == "Windows":
+        base = os.environ.get("LOCALAPPDATA")
+        if base:
+            return Path(base) / "findphotodates" / "Cache"
+        return Path.home() / "AppData" / "Local" / "findphotodates" / "Cache"
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    if xdg:
+        return Path(xdg) / "findphotodates"
+    return Path.home() / ".cache" / "findphotodates"
+
+
+DEFAULT_CACHE_DIR = _default_cache_dir()
+DEFAULT_HASH_CACHE_DIR = DEFAULT_CACHE_DIR  # backward-compat alias
+DEFAULT_HASH_CACHE_PATH = DEFAULT_CACHE_DIR / "hash_cache.sqlite"
+DEFAULT_LOCATION_CACHE_PATH = DEFAULT_CACHE_DIR / "location_cache.sqlite"
 HASH_CACHE_BATCH_COMMIT_EVERY = 1000
+LOCATION_CACHE_BATCH_COMMIT_EVERY = 1000
+LOCATION_CACHE_PRECISION = 2
 
 # ---------------------------------------------------------------------------
 # Cross-platform cache-key normalization (WSL ↔ Windows)
@@ -122,6 +143,44 @@ HASH_CACHE_BATCH_COMMIT_EVERY = 1000
 # after backslash → forward-slash conversion.
 
 _IS_TTY = sys.stdout.isatty()
+
+
+# Alan 5/4/26 - Cosmetic: detect whether the current terminal can render ANSI
+# escape sequences. POSIX TTYs always can; Windows is conservative — older
+# PowerShell 5 / cmd.exe will print raw "ESC[2K" garbage if we send it
+# unconditionally, so we only enable ANSI when the host advertises it
+# (Windows Terminal, ConEmu, ANSICON, or a real TERM).
+def _detect_ansi_support():
+    if not _IS_TTY:
+        return False
+    if os.name != "nt":
+        return True
+    if os.environ.get("WT_SESSION"):
+        return True  # Windows Terminal
+    if os.environ.get("ConEmuANSI", "").upper() == "ON":
+        return True
+    if "ANSICON" in os.environ:
+        return True
+    term = os.environ.get("TERM", "")
+    if term and term.lower() != "dumb":
+        return True
+    return False
+
+
+_ANSI_OK = _detect_ansi_support()
+
+
+def _clear_progress_line():
+    """Clear the carriage-return progress line before printing a summary.
+
+    On ANSI-capable terminals: emit "\\r\\x1b[2K" to wipe the line in place.
+    Otherwise: emit a newline so the next print starts cleanly without
+    leaking raw escape codes onto the screen.
+    """
+    if _ANSI_OK:
+        print("\r\033[2K", end="")
+    else:
+        print()
 
 _WSL_MOUNT_RE = re.compile(r"^/mnt/([a-zA-Z])/")
 _WIN_DRIVE_RE = re.compile(r"^([a-zA-Z]):[/\\]")
@@ -219,6 +278,31 @@ def _resolve_local_inventory_path(path):
     if not path:
         return path
     return os.path.abspath(format_path_style(path, _host_path_style()))
+
+
+def migrate_default_hash_cache(quiet=False, debug=False):
+    """Move the old Windows default hash cache into the native cache directory."""
+    if platform.system() != "Windows":
+        return False
+    old_path = Path.home() / ".cache" / "findphotodates" / "hash_cache.sqlite"
+    new_path = DEFAULT_HASH_CACHE_PATH
+    if old_path == new_path or not old_path.exists() or new_path.exists():
+        return False
+    try:
+        new_path.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(old_path, new_path)
+        for suffix in ("-wal", "-shm"):
+            old_sidecar = Path(str(old_path) + suffix)
+            new_sidecar = Path(str(new_path) + suffix)
+            if old_sidecar.exists() and not new_sidecar.exists():
+                os.replace(old_sidecar, new_sidecar)
+        if not quiet:
+            print(f"Moved existing hash cache to {new_path}")
+        return True
+    except Exception as e:
+        if debug:
+            print(f"Debug: Failed to migrate hash cache from {old_path}: {e}")
+        return False
 
 
 def detect_inventory_path_style(tsv_path):
@@ -361,6 +445,19 @@ def parse_hash_args(
         hash_exts=hash_exts,
         sample_algo=sample_algo,
         full_algo=full_algo,
+    )
+
+
+def parse_location_args(location_cache_path=None, no_location_cache=False):
+    """Parse and normalize reverse-geocoding cache options."""
+    use_cache = not no_location_cache
+    path = location_cache_path
+    if use_cache and path is None:
+        path = str(DEFAULT_LOCATION_CACHE_PATH)
+    return types.SimpleNamespace(
+        use_location_cache=use_cache,
+        location_cache_path=path,
+        precision=LOCATION_CACHE_PRECISION,
     )
 
 
@@ -526,6 +623,76 @@ def put_cached_hash(
         if pending_counter is not None:
             pending_counter[0] += 1
             if pending_counter[0] >= HASH_CACHE_BATCH_COMMIT_EVERY:
+                conn.commit()
+                pending_counter[0] = 0
+        else:
+            conn.commit()
+    except Exception:
+        pass
+
+
+def open_location_cache(cache_path, debug=False):
+    """Open SQLite location cache and ensure the expected table exists."""
+    try:
+        import sqlite3
+    except ImportError:
+        if debug:
+            print("Debug: sqlite3 module not found.")
+        return None
+    try:
+        Path(cache_path).parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(cache_path)
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.execute("PRAGMA synchronous=NORMAL;")
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS location_cache (
+                lat_rounded REAL NOT NULL,
+                lon_rounded REAL NOT NULL,
+                precision INTEGER NOT NULL,
+                location TEXT NOT NULL,
+                fetched_at INTEGER NOT NULL,
+                PRIMARY KEY (lat_rounded, lon_rounded, precision)
+            )
+        """)
+        conn.commit()
+        return conn
+    except Exception as e:
+        if debug:
+            print(f"Debug: Failed to open location cache at {cache_path}: {e}")
+        return None
+
+
+def get_cached_location(conn, lat_rounded, lon_rounded, precision):
+    """Return cached location string if present, else None."""
+    if conn is None:
+        return None
+    try:
+        row = conn.execute(
+            """SELECT location FROM location_cache
+               WHERE lat_rounded = ? AND lon_rounded = ? AND precision = ?""",
+            (lat_rounded, lon_rounded, precision),
+        ).fetchone()
+        return row[0] if row else None
+    except Exception:
+        return None
+
+
+def put_cached_location(
+    conn, lat_rounded, lon_rounded, precision, location, pending_counter=None
+):
+    """Store a resolved location in the SQLite cache."""
+    if conn is None or not location or is_coordinate_string(location):
+        return
+    try:
+        conn.execute(
+            """INSERT OR REPLACE INTO location_cache
+               (lat_rounded, lon_rounded, precision, location, fetched_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (lat_rounded, lon_rounded, precision, location, int(time.time())),
+        )
+        if pending_counter is not None:
+            pending_counter[0] += 1
+            if pending_counter[0] >= LOCATION_CACHE_BATCH_COMMIT_EVERY:
                 conn.commit()
                 pending_counter[0] = 0
         else:
@@ -731,12 +898,29 @@ class ExifToolPersistent:
         if self._proc is not None:
             return
         try:
+            # Alan 5/3/26 - Force UTF-8 on the pipes to ExifTool.  Without
+            # explicit encoding, Python uses the locale codec for text=True
+            # pipes, which on Windows is typically cp1252 and crashes with
+            # UnicodeEncodeError on filenames containing characters like
+            # U+202F (narrow no-break space).  "-charset filename=UTF8" tells
+            # ExifTool that filenames arriving on the -@ argfile pipe are
+            # UTF-8 rather than the active Windows code page.
             self._proc = subprocess.Popen(
-                ["exiftool", "-stay_open", "True", "-@", "-"],
+                [
+                    "exiftool",
+                    "-charset",
+                    "filename=UTF8",
+                    "-stay_open",
+                    "True",
+                    "-@",
+                    "-",
+                ],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
                 text=True,
+                encoding="utf-8",
+                errors="surrogateescape",
             )
         except FileNotFoundError as e:
             raise FileNotFoundError(
@@ -760,21 +944,56 @@ class ExifToolPersistent:
     def _send_and_read(self, args):
         """Send args to the persistent process and read lines until sentinel.
 
-        Returns list of stripped lines, or None on process death.
-        Retries once if the process dies mid-write.
+        Returns list of stripped lines, or None on process death or on a
+        UnicodeEncodeError that survived even after restarting the process
+        with UTF-8 pipes.  Retries once if the process dies mid-write.
         """
         if self._proc is None:
             self.start()
         proc = self._proc
+        payload = "\n".join(args) + "\n-execute\n"
         try:
-            proc.stdin.write("\n".join(args) + "\n-execute\n")
+            proc.stdin.write(payload)
             proc.stdin.flush()
         except (BrokenPipeError, OSError):
             self._proc = None
             self.start()
             proc = self._proc
-            proc.stdin.write("\n".join(args) + "\n-execute\n")
-            proc.stdin.flush()
+            # Alan 5/4/26 - Catch BrokenPipeError/OSError on the retry too:
+            # if the freshly-restarted ExifTool also dies during write/flush,
+            # we previously tracebacked. Treat this like the encode failure:
+            # warn, drop the process, return None so batch_query falls back
+            # and the file is recorded with blank EXIF.
+            try:
+                proc.stdin.write(payload)
+                proc.stdin.flush()
+            except (BrokenPipeError, OSError, UnicodeEncodeError) as e:
+                print(
+                    f"Warning: ExifTool retry write failed: {e!r}; args={args!r}",
+                    file=sys.stderr,
+                )
+                try:
+                    if self._proc is not None:
+                        self._proc.kill()
+                except Exception:
+                    pass
+                self._proc = None
+                return None
+        except UnicodeEncodeError as e:
+            # Should not happen with utf-8 pipes, but stay defensive: a single
+            # bad path must not abort the whole scan.  Restart the process
+            # (its stdin buffer state is now unknown) and let the caller fall
+            # back to per-file querying.
+            print(
+                f"Warning: ExifTool stdin encode failed: {e!r}; args={args!r}",
+                file=sys.stderr,
+            )
+            try:
+                self._proc.kill()
+            except Exception:
+                pass
+            self._proc = None
+            return None
 
         lines = []
         while True:
@@ -955,10 +1174,17 @@ def get_photo_data(filepath, _exiftool=None):
 
 # Global variables for geolocation rate limiting and coordinate caching
 _last_geolocate_time = 0
-_coord_cache = {}  # (round(lat,5), round(lon,5)) -> location
+_coord_cache = {}  # (round(lat,2), round(lon,2)) -> location
 
 
-def geolocate(lat, lon):
+def _coord_cache_key(lat, lon, precision=LOCATION_CACHE_PRECISION):
+    try:
+        return (round(float(lat), precision), round(float(lon), precision))
+    except (ValueError, TypeError):
+        return None
+
+
+def geolocate(lat, lon, location_conn=None, pending_counter=None):
     """Convert GPS coordinates to a human-readable location using Nominatim API."""
     global _last_geolocate_time
 
@@ -972,10 +1198,23 @@ def geolocate(lat, lon):
     except (ValueError, TypeError):
         return f"{lat}, {lon}"
 
-    # Check coordinate cache (round to 5 decimal places ~1.1m precision)
-    cache_key = (round(lat_float, 5), round(lon_float, 5))
+    # Check coordinate cache (round to 2 decimal places ~1 km precision)
+    cache_key = _coord_cache_key(lat_float, lon_float)
+    if cache_key is None:
+        return f"{lat}, {lon}"
     if cache_key in _coord_cache:
         return _coord_cache[cache_key]
+
+    lat_rounded, lon_rounded = cache_key
+    cached_location = get_cached_location(
+        location_conn,
+        lat_rounded,
+        lon_rounded,
+        LOCATION_CACHE_PRECISION,
+    )
+    if cached_location:
+        _coord_cache[cache_key] = cached_location
+        return cached_location
 
     # Rate limiting: wait at least 1 second since last request
     current_time = time.time()
@@ -1023,6 +1262,14 @@ def geolocate(lat, lon):
 
             # Cache the result
             _coord_cache[cache_key] = location
+            put_cached_location(
+                location_conn,
+                lat_rounded,
+                lon_rounded,
+                LOCATION_CACHE_PRECISION,
+                location,
+                pending_counter=pending_counter,
+            )
             return location
 
     except urllib.error.HTTPError as e:
@@ -1114,6 +1361,16 @@ def load_cache(output_file, debug=False):
                         gps_lat = row.get("gps_lat", "") or None
                         gps_lon = row.get("gps_lon", "") or None
                         location = row.get("location", "") or None
+
+                        if (
+                            gps_lat
+                            and gps_lon
+                            and location
+                            and not is_coordinate_string(location)
+                        ):
+                            coord_key = _coord_cache_key(gps_lat, gps_lon)
+                            if coord_key is not None:
+                                _coord_cache.setdefault(coord_key, location)
 
                         # Treat coordinate strings as missing location (allows retry)
                         if location and is_coordinate_string(location):
@@ -1336,6 +1593,189 @@ def summarize_results(photo_data, file_counts, quiet, debug=False):
 def _expand_path(p: str) -> str:
     """Expand user home directory and convert to absolute path."""
     return os.path.abspath(os.path.expanduser(p))
+
+
+# Alan 5/3/26 - Preflight helpers: catch predictable setup mistakes (bad
+# --output dir, unwritable parent, --output is a directory, missing input)
+# BEFORE a multi-minute scan starts, instead of crashing at first checkpoint
+# with a Python traceback.
+def _print_user_error(lines):
+    """Print a user-facing error block without a traceback.
+
+    Accepts either a single string or a list of strings (one per line).
+    """
+    if isinstance(lines, str):
+        lines = [lines]
+    for line in lines:
+        print(line)
+
+
+def _preflight_input_directory(directory):
+    """Validate the scan's input directory before discovery starts.
+
+    Returns True if usable. Returns False after printing a friendly,
+    traceback-free message if the directory is missing, is not a directory,
+    or cannot be opened.
+    """
+    if not os.path.exists(directory):
+        _print_user_error([
+            "Error: Input directory does not exist:",
+            f"  {directory}",
+            "The scan was not started.",
+            "Check the --directory argument for typos.",
+        ])
+        return False
+    if not os.path.isdir(directory):
+        _print_user_error([
+            "Error: --directory must be a directory, but this is a file:",
+            f"  {directory}",
+            "The scan was not started.",
+        ])
+        return False
+    try:
+        # Touch the directory listing to surface permission errors up front.
+        with os.scandir(directory) as it:
+            for _ in it:
+                break
+    except PermissionError as e:
+        _print_user_error([
+            "Error: Permission denied opening input directory:",
+            f"  {directory}",
+            f"  ({e})",
+            "The scan was not started.",
+        ])
+        return False
+    except OSError as e:
+        _print_user_error([
+            "Error: Cannot open input directory:",
+            f"  {directory}",
+            f"  ({e})",
+            "The scan was not started.",
+        ])
+        return False
+    return True
+
+
+def _preflight_output_path(output, raw_output=None):
+    """Validate that the output file path is usable before scanning starts.
+
+    Catches the common cases that would otherwise crash mid-scan:
+      - --output points at an existing directory
+      - parent directory does not exist (esp. Windows drive-root-relative typos)
+      - parent directory exists but is not writable
+
+    Returns True if usable. Returns False after printing a helpful message.
+    """
+    output_abs = os.path.abspath(output)
+
+    if os.path.isdir(output_abs):
+        _print_user_error([
+            "Error: --output must be a file path, but this is a directory:",
+            f"  {output_abs}",
+            "Choose a file path inside the directory instead.",
+            "The scan was not started.",
+        ])
+        return False
+
+    output_dir = os.path.dirname(output_abs) or "."
+
+    if not os.path.isdir(output_dir):
+        msg = [
+            "Error: Output directory does not exist:",
+            f"  {output_dir}",
+            "The scan was not started.",
+            "Create the directory or choose a valid --output path.",
+        ]
+        # Windows: a path beginning with a single backslash (but not "\\")
+        # is drive-root-relative — a frequent source of typos when the user
+        # meant their profile directory.
+        if platform.system() == "Windows" and raw_output:
+            if raw_output.startswith("\\") and not raw_output.startswith("\\\\"):
+                msg.append(
+                    f"On Windows, a path like {raw_output} is drive-root-relative"
+                )
+                msg.append(f"  and resolves to: {output_abs}")
+            user_profile = os.environ.get("USERPROFILE")
+            if user_profile:
+                msg.append("Your current profile directory is:")
+                msg.append(f"  {user_profile}")
+        _print_user_error(msg)
+        return False
+
+    # Try writing a small temp file to confirm the directory is writable.
+    # Doing this here means we fail fast instead of after a long scan when
+    # the first checkpoint tries (and fails) to mkstemp().
+    try:
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".findphotodates_preflight_", dir=output_dir
+        )
+        os.close(fd)
+        os.unlink(tmp_path)
+    except (PermissionError, OSError) as e:
+        _print_user_error([
+            "Error: Cannot write to output directory:",
+            f"  {output_dir}",
+            f"  ({e.__class__.__name__}: {e})",
+            "Choose a writable --output path or fix the directory permissions.",
+            "The scan was not started.",
+        ])
+        return False
+
+    return True
+
+
+def validate_scan_paths(directory, output, raw_output=None):
+    """Run all preflight checks for a scan. Returns True if both input and
+    output paths look usable, False otherwise. Friendly messages already
+    printed on failure.
+    """
+    if not _preflight_input_directory(directory):
+        return False
+    if not _preflight_output_path(output, raw_output=raw_output):
+        return False
+    return True
+
+
+def _safe_write_inventory(
+    output,
+    photo_data,
+    inventory_root,
+    hash_options,
+    old_format,
+    path_style,
+    debug=False,
+    context="write",
+):
+    """Wrap write_dates_to_file_atomic() with friendly error handling.
+
+    Returns True on success, False on a predictable filesystem error
+    (FileNotFoundError, PermissionError, OSError — disk full, access denied,
+    parent dir vanished, etc.). Re-raises only when --debug is set so the
+    full traceback is still available for unusual failures.
+    """
+    try:
+        write_dates_to_file_atomic(
+            output,
+            photo_data,
+            inventory_root=inventory_root,
+            hash_options=hash_options,
+            old_format=old_format,
+            path_style=path_style,
+        )
+        return True
+    except (FileNotFoundError, PermissionError, OSError) as e:
+        output_abs = os.path.abspath(output)
+        output_dir = os.path.dirname(output_abs) or "."
+        _print_user_error([
+            f"Error: Could not write inventory ({context}):",
+            f"  file:  {output_abs}",
+            f"  dir:   {output_dir}",
+            f"  cause: {e.__class__.__name__}: {e}",
+            "Progress could not be saved.",
+        ])
+        if debug:
+            raise
+        return False
 
 
 def _resolve_extensions(args):
@@ -1750,9 +2190,11 @@ def run_scan(
     quiet=False,
     debug=False,
     hash_options=None,
+    location_options=None,
     old_format=False,
     perf_stats=None,
     path_style="linux",  # safe internal default; CLI default is "auto" (resolved before calling)
+    raw_output=None,  # Alan 5/3/26 - original CLI --output arg, used only for friendly Windows path hints
 ):
     """Run a scan on the specified directory.
 
@@ -1764,8 +2206,18 @@ def run_scan(
     if path_style == "auto":
         path_style = resolve_output_path_style("auto", output, directory)
 
+    # Alan 5/3/26 - Validate input + output paths up front. This previously
+    # only checked that the input directory existed, and the output path was
+    # not validated at all — a bad --output dir would survive a multi-minute
+    # scan and then crash at the first checkpoint when tempfile.mkstemp()
+    # tried to create the temp file in a non-existent parent directory.
+    if not validate_scan_paths(directory, output, raw_output=raw_output):
+        return False
+
     if hash_options is None:
         hash_options = parse_hash_args(quiet=quiet)
+    if location_options is None:
+        location_options = parse_location_args()
 
     if old_format:
         # Force hashing off for old format
@@ -1777,6 +2229,12 @@ def run_scan(
         else None
     )
     hash_cache_pending = [0] if hash_conn else None
+    location_conn = (
+        open_location_cache(location_options.location_cache_path, debug=debug)
+        if (locate and location_options.use_location_cache)
+        else None
+    )
+    location_cache_pending = [0] if location_conn else None
 
     if not quiet and hash_options.hash_mode != "off":
         msg = f"Hashing enabled ({hash_options.hash_mode})"
@@ -1788,11 +2246,7 @@ def run_scan(
         print(msg)
 
     inventory_root = os.path.abspath(directory)
-    # Ensure the directory exists
-    if not os.path.exists(directory):
-        if not quiet:
-            print(f"Error: Directory '{directory}' does not exist.")
-        return False
+    # Alan 5/3/26 - Existing path check moved into validate_scan_paths() above.
 
     if not quiet:
         if extensions is None:
@@ -1843,6 +2297,16 @@ def run_scan(
                 if hash_cache_pending is not None and hash_cache_pending[0] > 0:
                     hash_conn.commit()
                 hash_conn.close()
+            except Exception:
+                pass
+        if location_conn is not None:
+            try:
+                if (
+                    location_cache_pending is not None
+                    and location_cache_pending[0] > 0
+                ):
+                    location_conn.commit()
+                location_conn.close()
             except Exception:
                 pass
 
@@ -1901,7 +2365,12 @@ def run_scan(
                 )
                 location = None
                 if locate and gps_lat and gps_lon:
-                    location = geolocate(gps_lat, gps_lon)
+                    location = geolocate(
+                        gps_lat,
+                        gps_lon,
+                        location_conn=location_conn,
+                        pending_counter=location_cache_pending,
+                    )
                     if location and is_coordinate_string(location):
                         location = None
                 _th0 = time.time()
@@ -1979,10 +2448,7 @@ def run_scan(
                     total_files = discovery.total
                     if not quiet:
                         # Clear \r progress line, then print clean discovery summary
-                        if _IS_TTY:
-                            print("\r\033[2K", end="")
-                        else:
-                            print()
+                        _clear_progress_line()
                         print(f"Discovery complete: {total_files:,} files found.")
 
                 try:
@@ -2029,7 +2495,12 @@ def run_scan(
 
                         if locate and gps_lat and gps_lon:
                             if not location or is_coordinate_string(location):
-                                location = geolocate(gps_lat, gps_lon)
+                                location = geolocate(
+                                    gps_lat,
+                                    gps_lon,
+                                    location_conn=location_conn,
+                                    pending_counter=location_cache_pending,
+                                )
                                 cached_entry["location"] = location
 
                         _th0 = time.time()
@@ -2121,22 +2592,42 @@ def run_scan(
                 # Checkpoint every 15 minutes
                 if total_seen > 0 and (current_time - last_save_time) > 900:
                     _tc0 = time.time()
-                    write_dates_to_file_atomic(
+                    # Alan 5/3/26 - Use _safe_write_inventory so a transient
+                    # write failure (drive removed, dir vanished, disk full,
+                    # ACL change mid-scan) prints a friendly message instead
+                    # of a Python traceback.
+                    _ckpt_ok = _safe_write_inventory(
                         output,
                         photo_data,
-                        inventory_root=inventory_root,
-                        hash_options=hash_options,
-                        old_format=old_format,
-                        path_style=path_style,
+                        inventory_root,
+                        hash_options,
+                        old_format,
+                        path_style,
+                        debug=debug,
+                        context="checkpoint",
                     )
                     _t_checkpoint_total += time.time() - _tc0
                     last_save_time = current_time
                     if not quiet:
-                        if _IS_TTY:
-                            print("\r\033[2K", end="")
-                        else:
-                            print()
-                        print(f"[Checkpoint: {len(photo_data):,} files saved]")
+                        _clear_progress_line()
+                        if _ckpt_ok:
+                            print(f"[Checkpoint: {len(photo_data):,} files saved]")
+                    # Alan 5/4/26 - If the checkpoint failed, stop the scan
+                    # rather than continuing with unsaved data for hours.
+                    # The final write would just hit the same error, and
+                    # the user needs to fix the underlying issue (bad path,
+                    # full disk, revoked permissions) before any rerun.
+                    if not _ckpt_ok:
+                        print(
+                            "Error: Checkpoint failed; stopping scan so you can "
+                            "fix the output path/disk/permissions and rerun."
+                        )
+                        try:
+                            exiftool.stop()
+                        except Exception:
+                            pass
+                        cleanup_all()
+                        return False
 
                 # Progress line every 2 seconds
                 if not quiet and (current_time - last_progress_time) >= 2.0:
@@ -2169,16 +2660,21 @@ def run_scan(
             print(
                 f"\n\nInterrupted! Saving progress ({len(photo_data):,} files processed so far)..."
             )
+            # Alan 5/3/26 - _safe_write_inventory already prints a friendly
+            # error block on predictable failures; only show a generic
+            # warning for unexpected exceptions.
             try:
-                write_dates_to_file_atomic(
+                if _safe_write_inventory(
                     output,
                     photo_data,
-                    inventory_root=inventory_root,
-                    hash_options=hash_options,
-                    old_format=old_format,
-                    path_style=path_style,
-                )
-                print(f"Progress saved to '{output}'.")
+                    inventory_root,
+                    hash_options,
+                    old_format,
+                    path_style,
+                    debug=debug,
+                    context="interrupted save",
+                ):
+                    print(f"Progress saved to '{output}'.")
             except Exception as save_err:
                 print(f"WARNING: Could not save progress: {save_err}")
             print("\nTo resume, run the same command again:")
@@ -2205,24 +2701,30 @@ def run_scan(
     if not quiet:
         elapsed = time.time() - start_time
         # Clear \r progress line, then print clean completion summary
-        if _IS_TTY:
-            print("\r\033[2K", end="")
-        else:
-            print()
+        _clear_progress_line()
         print(
             f"Processing complete: {total_seen:,} files in {_format_duration(elapsed)}."
         )
 
     _tw0 = time.time()
-    write_dates_to_file_atomic(
+    # Alan 5/3/26 - Wrap final write in _safe_write_inventory so the user
+    # gets a friendly error (not a Python traceback) if the output dir
+    # disappeared, filled up, or revoked write access during the scan.
+    _final_ok = _safe_write_inventory(
         output,
         photo_data,
-        inventory_root=inventory_root,
-        hash_options=hash_options,
-        old_format=old_format,
-        path_style=path_style,
+        inventory_root,
+        hash_options,
+        old_format,
+        path_style,
+        debug=debug,
+        context="final write",
     )
     _t_write = time.time() - _tw0
+
+    if not _final_ok:
+        cleanup_all()
+        return False
 
     if not quiet:
         print(f"Dates written to '{output}' ({len(photo_data):,} files listed).")
@@ -2613,7 +3115,7 @@ Key Features:
   - Extracts 'Date Taken' and GPS from media files via ExifTool.
   - Caches results in a TSV file to speed up subsequent runs.
   - Optional content hashing (--hash sample) for backup/deduplication safety.
-  - Can reverse geolocate files using GPS coordinates (--locate).
+  - Can reverse geolocate files using GPS coordinates (--locate), with persistent caching.
   - Can save and manage multiple scan configurations (--save, --scan).
 
 Usage: findphotodates.py [options]
@@ -2635,7 +3137,11 @@ Options:
   --video            Index only video files (MP4, MOV, AVI, etc.).
   --extension EXT    Index only a specific file extension (e.g., --extension pdf).
   --locate           Attempt to reverse geolocate files using GPS coordinates.
+  --location-cache PATH  Path to SQLite reverse-geocoding cache.
+  --no-location-cache    Disable persistent reverse-geocoding cache.
   --hash {sample,full,off}  Hashing mode (default: off). Use --hash sample to enable.
+  --hash-cache PATH        Path to SQLite hash cache.
+  --no-hash-cache          Disable hash cache.
   --add-hashes             Fill in missing hashes for an existing inventory file.
   --old-format       Write legacy line-based output (./path: YYYY:MM:DD HH:MM:SS) without hashes.
   --save             Save the current scan configuration for later use.
@@ -2687,7 +3193,7 @@ For more details on a specific option, you can also use:
     parser.add_argument(
         "--locate",
         action="store_true",
-        help="Attempt to locate files using GPS coordinates.",
+        help="Attempt to locate files using GPS coordinates. Uses a persistent SQLite cache by default.",
     )
     parser.add_argument(
         "--test", action="store_true", help="Run date parsing tests and exit."
@@ -2726,6 +3232,17 @@ For more details on a specific option, you can also use:
     )
     parser.add_argument(
         "--no-hash-cache", action="store_true", help="Disable hash cache."
+    )
+    parser.add_argument(
+        "--location-cache",
+        metavar="PATH",
+        default=None,
+        help="Path to SQLite reverse-geocoding cache.",
+    )
+    parser.add_argument(
+        "--no-location-cache",
+        action="store_true",
+        help="Disable persistent reverse-geocoding cache.",
     )
     parser.add_argument(
         "--hash-exts",
@@ -2782,10 +3299,16 @@ For more details on a specific option, you can also use:
         hash_exts_str=args.hash_exts,
         quiet=args.quiet,
     )
+    location_options = parse_location_args(
+        location_cache_path=args.location_cache,
+        no_location_cache=args.no_location_cache,
+    )
 
     if args.test:
         test_date_parsing()
         return
+
+    migrate_default_hash_cache(quiet=args.quiet, debug=args.debug)
 
     if args.add_hashes:
         output_abs = _expand_path(output)
@@ -2802,9 +3325,10 @@ For more details on a specific option, you can also use:
     if args.save:
         directory_abs = _expand_path(args.directory)
         output_abs = _expand_path(output)
-        if not os.path.exists(directory_abs):
-            print(f"Error: Directory '{directory_abs}' does not exist.")
-            return
+        # Alan 5/3/26 - Use the shared input-directory preflight so --save
+        # gives the same friendly error as a regular scan and exits nonzero.
+        if not _preflight_input_directory(directory_abs):
+            sys.exit(1)
 
         drive_root, path_relative = detect_drive_root(directory_abs)
         drive_hint_value = get_drive_hint(drive_root)
@@ -2834,6 +3358,8 @@ For more details on a specific option, you can also use:
             "hash_algo": args.hash_algo,
             "hash_cache": args.hash_cache,
             "no_hash_cache": args.no_hash_cache,
+            "location_cache": args.location_cache,
+            "no_location_cache": args.no_location_cache,
             "hash_exts": args.hash_exts,
             "old_format": args.old_format,
             "path_style": args.path_style,
@@ -2887,7 +3413,10 @@ For more details on a specific option, you can also use:
         else:
             extensions = _resolve_extensions(args)
             scan_perf = {}
-            run_scan(
+            # Alan 5/3/26 - Pass raw --output through so preflight can give
+            # Windows-specific hints (e.g. "\Users\..." is drive-root-relative)
+            # and propagate run_scan's False return as a nonzero process exit.
+            ok = run_scan(
                 directory_abs,
                 output_abs,
                 extensions,
@@ -2895,15 +3424,19 @@ For more details on a specific option, you can also use:
                 args.quiet,
                 args.debug,
                 hash_options=hash_options,
+                location_options=location_options,
                 old_format=args.old_format,
                 perf_stats=scan_perf,
                 path_style=args.path_style,
+                raw_output=output,
             )
             if scan_perf and (
                 # Print a performance summary if the run takes more than 1000 seconds
                 args.debugperformance or scan_perf.get("wall_total", 0) >= 1000
             ):
                 _print_perf_summary(directory_abs, scan_perf)
+            if ok is False:
+                sys.exit(1)
             return
 
     if args.scan:
@@ -2913,6 +3446,7 @@ For more details on a specific option, you can also use:
             return
 
         all_perf = []
+        any_scan_failed = False
         print(f"Running {len(config['saved_scans'])} saved scan(s)...")
         for idx, entry in enumerate(config["saved_scans"], 1):
             resolved_dir = resolve_saved_directory(entry)
@@ -2934,11 +3468,17 @@ For more details on a specific option, you can also use:
                 hash_exts_str=flags.get("hash_exts"),
                 quiet=args.quiet,
             )
+            scan_location_options = parse_location_args(
+                location_cache_path=flags.get("location_cache"),
+                no_location_cache=flags.get("no_location_cache", False),
+            )
             saved_exts = flags.get("extensions")
             extensions = set(saved_exts) if saved_exts is not None else None
             scan_perf = {}
+            # Alan 5/3/26 - Track per-saved-scan failures so we can exit
+            # nonzero at the end if any saved scan failed preflight or write.
             try:
-                run_scan(
+                ok = run_scan(
                     resolved_dir,
                     entry.get("output_abs", "photo.dates.tsv"),
                     extensions,
@@ -2946,12 +3486,16 @@ For more details on a specific option, you can also use:
                     flags.get("quiet", False),
                     flags.get("debug", False),
                     hash_options=scan_hash_options,
+                    location_options=scan_location_options,
                     old_format=flags.get("old_format", False),
                     perf_stats=scan_perf,
                     path_style=flags.get("path_style", "auto"),
                 )
+                if ok is False:
+                    any_scan_failed = True
             except Exception as e:
                 print(f"  Error: {e}")
+                any_scan_failed = True
             # Add summary if the --debugperformance option is used, or if the run takes more than 1000 seconds
             if scan_perf:
                 if args.debugperformance or scan_perf.get("wall_total", 0) >= 1000:
@@ -2968,13 +3512,19 @@ For more details on a specific option, you can also use:
                 files = stats.get("files_total", 0)
                 print(f"  {name:<30s} {wall:7.1f}s  {files:>8,} files")
             print(f"  {'TOTAL':<30s} {total_wall:7.1f}s  {total_files:>8,} files")
+        # Alan 5/3/26 - Surface saved-scan failures via process exit code so
+        # automation/scripting can notice when a saved scan failed preflight.
+        if any_scan_failed:
+            sys.exit(1)
         return
 
     directory_abs = _expand_path(args.directory)
     output_abs = _expand_path(output)
     extensions = _resolve_extensions(args)
     scan_perf = {}
-    run_scan(
+    # Alan 5/3/26 - Pass raw --output through (used only for friendly Windows
+    # path hints in preflight) and translate False return into nonzero exit.
+    ok = run_scan(
         directory_abs,
         output_abs,
         extensions,
@@ -2982,12 +3532,16 @@ For more details on a specific option, you can also use:
         args.quiet,
         args.debug,
         hash_options=hash_options,
+        location_options=location_options,
         old_format=args.old_format,
         perf_stats=scan_perf,
         path_style=args.path_style,
+        raw_output=output,
     )
     if scan_perf and (args.debugperformance or scan_perf.get("wall_total", 0) >= 1000):
         _print_perf_summary(directory_abs, scan_perf)
+    if ok is False:
+        sys.exit(1)
 
 
 def test_date_parsing():

--- a/findphotodates.py
+++ b/findphotodates.py
@@ -126,6 +126,8 @@ DEFAULT_LOCATION_CACHE_PATH = DEFAULT_CACHE_DIR / "location_cache.sqlite"
 HASH_CACHE_BATCH_COMMIT_EVERY = 1000
 LOCATION_CACHE_BATCH_COMMIT_EVERY = 1000
 LOCATION_CACHE_PRECISION = 2
+WORKER_SHUTDOWN_TIMEOUT_SECONDS = 60
+_sqlite_lock = threading.Lock()
 
 # ---------------------------------------------------------------------------
 # Cross-platform cache-key normalization (WSL ↔ Windows)
@@ -556,7 +558,7 @@ def open_sqlite_cache(cache_path, debug=False):
         return None
     try:
         Path(cache_path).parent.mkdir(parents=True, exist_ok=True)
-        conn = sqlite3.connect(cache_path)
+        conn = sqlite3.connect(cache_path, check_same_thread=False)
         conn.execute("PRAGMA journal_mode=WAL;")
         conn.execute("PRAGMA synchronous=NORMAL;")
         conn.execute("""
@@ -587,12 +589,13 @@ def get_cached_hash(
     if conn is None:
         return None
     try:
-        row = conn.execute(
-            """SELECT digest FROM hash_cache
-               WHERE path = ? AND size_bytes = ? AND mtime_ns = ?
-                 AND hash_mode = ? AND chunk_bytes = ? AND chunks = ? AND algo = ?""",
-            (path, size_bytes, mtime_ns, hash_mode, chunk_bytes, chunks, algo),
-        ).fetchone()
+        with _sqlite_lock:
+            row = conn.execute(
+                """SELECT digest FROM hash_cache
+                   WHERE path = ? AND size_bytes = ? AND mtime_ns = ?
+                     AND hash_mode = ? AND chunk_bytes = ? AND chunks = ? AND algo = ?""",
+                (path, size_bytes, mtime_ns, hash_mode, chunk_bytes, chunks, algo),
+            ).fetchone()
         return row[0] if row else None
     except Exception:
         return None
@@ -614,19 +617,29 @@ def put_cached_hash(
     if conn is None:
         return
     try:
-        conn.execute(
-            """INSERT OR REPLACE INTO hash_cache
-               (path, size_bytes, mtime_ns, hash_mode, chunk_bytes, chunks, algo, digest)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-            (path, size_bytes, mtime_ns, hash_mode, chunk_bytes, chunks, algo, digest),
-        )
-        if pending_counter is not None:
-            pending_counter[0] += 1
-            if pending_counter[0] >= HASH_CACHE_BATCH_COMMIT_EVERY:
+        with _sqlite_lock:
+            conn.execute(
+                """INSERT OR REPLACE INTO hash_cache
+                   (path, size_bytes, mtime_ns, hash_mode, chunk_bytes, chunks, algo, digest)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    path,
+                    size_bytes,
+                    mtime_ns,
+                    hash_mode,
+                    chunk_bytes,
+                    chunks,
+                    algo,
+                    digest,
+                ),
+            )
+            if pending_counter is not None:
+                pending_counter[0] += 1
+                if pending_counter[0] >= HASH_CACHE_BATCH_COMMIT_EVERY:
+                    conn.commit()
+                    pending_counter[0] = 0
+            else:
                 conn.commit()
-                pending_counter[0] = 0
-        else:
-            conn.commit()
     except Exception:
         pass
 
@@ -641,7 +654,7 @@ def open_location_cache(cache_path, debug=False):
         return None
     try:
         Path(cache_path).parent.mkdir(parents=True, exist_ok=True)
-        conn = sqlite3.connect(cache_path)
+        conn = sqlite3.connect(cache_path, check_same_thread=False)
         conn.execute("PRAGMA journal_mode=WAL;")
         conn.execute("PRAGMA synchronous=NORMAL;")
         conn.execute("""
@@ -667,11 +680,12 @@ def get_cached_location(conn, lat_rounded, lon_rounded, precision):
     if conn is None:
         return None
     try:
-        row = conn.execute(
-            """SELECT location FROM location_cache
-               WHERE lat_rounded = ? AND lon_rounded = ? AND precision = ?""",
-            (lat_rounded, lon_rounded, precision),
-        ).fetchone()
+        with _sqlite_lock:
+            row = conn.execute(
+                """SELECT location FROM location_cache
+                   WHERE lat_rounded = ? AND lon_rounded = ? AND precision = ?""",
+                (lat_rounded, lon_rounded, precision),
+            ).fetchone()
         return row[0] if row else None
     except Exception:
         return None
@@ -684,19 +698,20 @@ def put_cached_location(
     if conn is None or not location or is_coordinate_string(location):
         return
     try:
-        conn.execute(
-            """INSERT OR REPLACE INTO location_cache
-               (lat_rounded, lon_rounded, precision, location, fetched_at)
-               VALUES (?, ?, ?, ?, ?)""",
-            (lat_rounded, lon_rounded, precision, location, int(time.time())),
-        )
-        if pending_counter is not None:
-            pending_counter[0] += 1
-            if pending_counter[0] >= LOCATION_CACHE_BATCH_COMMIT_EVERY:
+        with _sqlite_lock:
+            conn.execute(
+                """INSERT OR REPLACE INTO location_cache
+                   (lat_rounded, lon_rounded, precision, location, fetched_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (lat_rounded, lon_rounded, precision, location, int(time.time())),
+            )
+            if pending_counter is not None:
+                pending_counter[0] += 1
+                if pending_counter[0] >= LOCATION_CACHE_BATCH_COMMIT_EVERY:
+                    conn.commit()
+                    pending_counter[0] = 0
+            else:
                 conn.commit()
-                pending_counter[0] = 0
-        else:
-            conn.commit()
     except Exception:
         pass
 
@@ -1175,6 +1190,7 @@ def get_photo_data(filepath, _exiftool=None):
 # Global variables for geolocation rate limiting and coordinate caching
 _last_geolocate_time = 0
 _coord_cache = {}  # (round(lat,2), round(lon,2)) -> location
+_geolocate_lock = threading.Lock()
 
 
 def _coord_cache_key(lat, lon, precision=LOCATION_CACHE_PRECISION):
@@ -1213,77 +1229,88 @@ def geolocate(lat, lon, location_conn=None, pending_counter=None):
         LOCATION_CACHE_PRECISION,
     )
     if cached_location:
-        _coord_cache[cache_key] = cached_location
+        with _geolocate_lock:
+            _coord_cache[cache_key] = cached_location
         return cached_location
 
-    # Rate limiting: wait at least 1 second since last request
-    current_time = time.time()
-    time_since_last = current_time - _last_geolocate_time
-    if time_since_last < 1.0:
-        time.sleep(1.0 - time_since_last)
+    with _geolocate_lock:
+        # Rate limiting: wait at least 1 second since last request
+        current_time = time.time()
+        time_since_last = current_time - _last_geolocate_time
+        if time_since_last < 1.0:
+            time.sleep(1.0 - time_since_last)
 
-    try:
-        # Build Nominatim reverse geocoding URL with addressdetails=1
-        url = f"https://nominatim.openstreetmap.org/reverse?format=json&lat={lat_float}&lon={lon_float}&addressdetails=1"
+        try:
+            # Build Nominatim reverse geocoding URL with addressdetails=1
+            url = f"https://nominatim.openstreetmap.org/reverse?format=json&lat={lat_float}&lon={lon_float}&addressdetails=1"
 
-        # Create request with proper User-Agent header (required by Nominatim)
-        req = urllib.request.Request(url)
-        req.add_header(
-            "User-Agent",
-            "findphotodates.py/1.5 (https://github.com/alanrockefeller/findphotodates.py)",
-        )
-
-        # Make the request
-        with urllib.request.urlopen(req, timeout=10) as response:
-            data = json.loads(response.read().decode())
-
-            # Update last request time
-            _last_geolocate_time = time.time()
-
-            # Extract location from response - prefer address components over display_name
-            location = None
-            if "address" in data:
-                addr = data["address"]
-                parts = []
-                # Build location from address components in order of specificity
-                for key in ["city", "town", "village", "county", "state", "country"]:
-                    if key in addr:
-                        parts.append(addr[key])
-                if parts:
-                    location = ", ".join(parts)
-
-            # Fallback to display_name if address components didn't work
-            if not location and "display_name" in data:
-                location = data["display_name"]
-
-            # Fallback to coordinates if no location found
-            if not location:
-                location = f"{lat_float}, {lon_float}"
-
-            # Cache the result
-            _coord_cache[cache_key] = location
-            put_cached_location(
-                location_conn,
-                lat_rounded,
-                lon_rounded,
-                LOCATION_CACHE_PRECISION,
-                location,
-                pending_counter=pending_counter,
+            # Create request with proper User-Agent header (required by Nominatim)
+            req = urllib.request.Request(url)
+            req.add_header(
+                "User-Agent",
+                "findphotodates.py/1.5 (https://github.com/alanrockefeller/findphotodates.py)",
             )
-            return location
 
-    except urllib.error.HTTPError as e:
-        # Handle 429 (rate limit) with longer backoff
-        if e.code == 429:
-            _last_geolocate_time = time.time() + 5  # Wait 5 seconds before next attempt
-        else:
+            # Make the request
+            with urllib.request.urlopen(req, timeout=10) as response:
+                data = json.loads(response.read().decode())
+
+                # Update last request time
+                _last_geolocate_time = time.time()
+
+                # Extract location from response - prefer address components over display_name
+                location = None
+                if "address" in data:
+                    addr = data["address"]
+                    parts = []
+                    # Build location from address components in order of specificity
+                    for key in [
+                        "city",
+                        "town",
+                        "village",
+                        "county",
+                        "state",
+                        "country",
+                    ]:
+                        if key in addr:
+                            parts.append(addr[key])
+                    if parts:
+                        location = ", ".join(parts)
+
+                # Fallback to display_name if address components didn't work
+                if not location and "display_name" in data:
+                    location = data["display_name"]
+
+                # Fallback to coordinates if no location found
+                if not location:
+                    location = f"{lat_float}, {lon_float}"
+
+        except urllib.error.HTTPError as e:
+            # Handle 429 (rate limit) with longer backoff
+            if e.code == 429:
+                _last_geolocate_time = (
+                    time.time() + 5
+                )  # Wait 5 seconds before next attempt
+            else:
+                _last_geolocate_time = time.time()
+            # Don't cache fallback coordinates - allow retry on next run
+            return f"{lat_float}, {lon_float}"
+        except Exception:
+            # Don't cache fallback coordinates - allow retry on next run
             _last_geolocate_time = time.time()
-        # Don't cache fallback coordinates - allow retry on next run
-        return f"{lat_float}, {lon_float}"
-    except Exception:
-        # Don't cache fallback coordinates - allow retry on next run
-        _last_geolocate_time = time.time()
-        return f"{lat_float}, {lon_float}"
+            return f"{lat_float}, {lon_float}"
+
+    with _geolocate_lock:
+        _coord_cache[cache_key] = location
+    put_cached_location(
+        location_conn,
+        lat_rounded,
+        lon_rounded,
+        LOCATION_CACHE_PRECISION,
+        location,
+        pending_counter=pending_counter,
+    )
+    return location
 
 
 def is_coordinate_string(location):
@@ -1370,7 +1397,8 @@ def load_cache(output_file, debug=False):
                         ):
                             coord_key = _coord_cache_key(gps_lat, gps_lon)
                             if coord_key is not None:
-                                _coord_cache.setdefault(coord_key, location)
+                                with _geolocate_lock:
+                                    _coord_cache.setdefault(coord_key, location)
 
                         # Treat coordinate strings as missing location (allows retry)
                         if location and is_coordinate_string(location):
@@ -2177,6 +2205,177 @@ def _format_eta(remaining_files, rate):
         return f"{int(secs)}s"
 
 
+def _clamp_worker_count(workers):
+    try:
+        return max(1, min(32, int(workers)))
+    except (TypeError, ValueError):
+        return 4
+
+
+def _log_worker_error(error_log, error_log_lock, message):
+    with error_log_lock:
+        error_log.write(message + "\n")
+        error_log.flush()
+
+
+def _build_exiftool_rows(
+    batch,
+    batch_results,
+    locate,
+    location_conn,
+    location_cache_pending,
+    hash_options,
+    hash_conn,
+    hash_cache_pending,
+):
+    results = []
+    file_counts = Counter()
+    stats = {"t_hashing": 0.0, "t_geolocate": 0.0}
+    for out_path, os_path, key_path, size_bytes, mtime_ns, ext in batch:
+        date_taken, gps_lat, gps_lon = batch_results.get(os_path, (None, None, None))
+        location = None
+        if locate and gps_lat and gps_lon:
+            _tg0 = time.time()
+            location = geolocate(
+                gps_lat,
+                gps_lon,
+                location_conn=location_conn,
+                pending_counter=location_cache_pending,
+            )
+            stats["t_geolocate"] += time.time() - _tg0
+            if location and is_coordinate_string(location):
+                location = None
+        _th0 = time.time()
+        content_hash = get_content_hash(
+            key_path,
+            size_bytes,
+            mtime_ns,
+            hash_options,
+            hash_conn,
+            hash_cache_pending,
+            os_path=os_path,
+        )
+        stats["t_hashing"] += time.time() - _th0
+        results.append(
+            (
+                out_path,
+                date_taken or "",
+                size_bytes,
+                mtime_ns,
+                gps_lat or "",
+                gps_lon or "",
+                location or "",
+                content_hash,
+            )
+        )
+        file_counts[ext] += 1
+    return results, file_counts, stats
+
+
+def _exiftool_worker(
+    worker_id,
+    work_queue,
+    results_queue,
+    stop_event,
+    locate,
+    hash_options,
+    hash_conn,
+    hash_cache_pending,
+    location_conn,
+    location_cache_pending,
+    error_log,
+    error_log_lock,
+):
+    exiftool = None
+    worker_started = time.time()
+    worker_stats = {
+        "worker_id": worker_id,
+        "wall": 0.0,
+        "t_active": 0.0,
+        "t_exiftool": 0.0,
+        "t_hashing": 0.0,
+        "t_geolocate": 0.0,
+        "t_queue_push": 0.0,
+        "batches": 0,
+        "files": 0,
+        "errors": 0,
+    }
+    try:
+        while not stop_event.is_set():
+            try:
+                batch = work_queue.get(timeout=0.5)
+            except queue.Empty:
+                continue
+            if batch is None:
+                break
+
+            _t_active_start = time.time()
+            batch_results = None
+            t_exiftool = 0.0
+            try:
+                if exiftool is None:
+                    exiftool = ExifToolPersistent()
+                    exiftool.start()
+                os_paths = [item[1] for item in batch]
+                _te0 = time.time()
+                batch_results = exiftool.batch_query(os_paths)
+                t_exiftool = time.time() - _te0
+                worker_stats["t_exiftool"] += t_exiftool
+                if batch_results is None:
+                    batch_results = {item[1]: (None, None, None) for item in batch}
+            except Exception as e:
+                worker_stats["errors"] += 1
+                _log_worker_error(
+                    error_log,
+                    error_log_lock,
+                    f"Warning: ExifTool worker {worker_id} failed; recording {len(batch)} file(s) with blank EXIF: {e!r}",
+                )
+                batch_results = {item[1]: (None, None, None) for item in batch}
+
+            results, file_counts, stats = _build_exiftool_rows(
+                batch,
+                batch_results,
+                locate,
+                location_conn,
+                location_cache_pending,
+                hash_options,
+                hash_conn,
+                hash_cache_pending,
+            )
+            worker_stats["t_hashing"] += stats["t_hashing"]
+            worker_stats["t_geolocate"] += stats["t_geolocate"]
+            worker_stats["batches"] += 1
+            worker_stats["files"] += len(results)
+
+            packet = {
+                "type": "results",
+                "results": results,
+                "file_counts": file_counts,
+                "t_exiftool": t_exiftool,
+                "t_hashing": stats["t_hashing"],
+                "t_geolocate": stats["t_geolocate"],
+            }
+            _tq0 = time.time()
+            results_queue.put(packet)
+            worker_stats["t_queue_push"] += time.time() - _tq0
+            worker_stats["t_active"] += time.time() - _t_active_start
+    except Exception as e:
+        worker_stats["errors"] += 1
+        _log_worker_error(
+            error_log,
+            error_log_lock,
+            f"Warning: ExifTool worker {worker_id} stopped unexpectedly: {e!r}",
+        )
+    finally:
+        if exiftool is not None:
+            try:
+                exiftool.stop()
+            except Exception:
+                pass
+        worker_stats["wall"] = time.time() - worker_started
+        results_queue.put({"type": "worker_done", "stats": worker_stats})
+
+
 # ---------------------------------------------------------------------------
 # Main scan loop
 # ---------------------------------------------------------------------------
@@ -2195,12 +2394,14 @@ def run_scan(
     perf_stats=None,
     path_style="linux",  # safe internal default; CLI default is "auto" (resolved before calling)
     raw_output=None,  # Alan 5/3/26 - original CLI --output arg, used only for friendly Windows path hints
+    workers=4,
 ):
     """Run a scan on the specified directory.
 
     If perf_stats is a dict, it will be populated with detailed timing breakdowns.
     """
     _t0 = time.time()
+    worker_count = _clamp_worker_count(workers)
 
     # Resolve "auto" path style once, before any writes.
     if path_style == "auto":
@@ -2289,28 +2490,33 @@ def run_scan(
     _t_cache_lookup_total = 0.0
     _t_exiftool_total = 0.0
     _t_hashing_total = 0.0
+    _t_geolocate_total = 0.0
     _t_checkpoint_total = 0.0
+    _t_dispatch_wait = 0.0
+    _t_results_wait = 0.0
+    _t_worker_total = 0.0
+    _worker_details = []
 
     def cleanup_all():
         if hash_conn is not None:
             try:
-                if hash_cache_pending is not None and hash_cache_pending[0] > 0:
-                    hash_conn.commit()
+                with _sqlite_lock:
+                    if hash_cache_pending is not None and hash_cache_pending[0] > 0:
+                        hash_conn.commit()
                 hash_conn.close()
             except Exception:
                 pass
         if location_conn is not None:
             try:
-                if (
-                    location_cache_pending is not None
-                    and location_cache_pending[0] > 0
-                ):
-                    location_conn.commit()
+                with _sqlite_lock:
+                    if (
+                        location_cache_pending is not None
+                        and location_cache_pending[0] > 0
+                    ):
+                        location_conn.commit()
                 location_conn.close()
             except Exception:
                 pass
-
-    exiftool = ExifToolPersistent()
 
     # --- Start background file discovery ---
     file_queue = queue.Queue(maxsize=_DISCOVERY_QUEUE_SIZE)
@@ -2326,13 +2532,6 @@ def run_scan(
     interrupted = False
 
     with open(error_log_path, "w", encoding="utf-8") as error_log:
-        try:
-            exiftool.start()
-        except FileNotFoundError:
-            print("Error: ExifTool is required but was not found.")
-            discovery.done.wait(timeout=2)
-            return False
-
         start_time = time.time()
         last_save_time = start_time
         last_progress_time = start_time
@@ -2342,87 +2541,221 @@ def run_scan(
         )
         total_files = 0  # set once discovery finishes
 
+        work_queue = queue.Queue(maxsize=max(1, worker_count * 4))
+        results_queue = queue.Queue()
+        stop_event = threading.Event()
+        error_log_lock = threading.Lock()
+        worker_threads = []
+        worker_done_count = 0
+
+        for worker_id in range(1, worker_count + 1):
+            t = threading.Thread(
+                target=_exiftool_worker,
+                args=(
+                    worker_id,
+                    work_queue,
+                    results_queue,
+                    stop_event,
+                    locate,
+                    hash_options,
+                    hash_conn,
+                    hash_cache_pending,
+                    location_conn,
+                    location_cache_pending,
+                    error_log,
+                    error_log_lock,
+                ),
+                daemon=True,
+            )
+            t.start()
+            worker_threads.append(t)
+
         # Batch buffer for files that need exiftool queries
-        # Each entry: (out_path, os_path, key_path, size_bytes, mtime_ns)
+        # Each entry: (out_path, os_path, key_path, size_bytes, mtime_ns, ext)
         #   out_path  — abspath written to TSV (human-visible)
         #   os_path   — actual filesystem path for exiftool / hashing I/O
         #   key_path  — normalized cache key for TSV cache and hash cache lookups
         exiftool_batch = []
 
-        def _flush_exiftool_batch():
-            """Send accumulated files to exiftool as one batch and process results."""
+        def _drain_results():
             nonlocal processed_count, _t_exiftool_total, _t_hashing_total
-            if not exiftool_batch:
-                return
-            os_paths = [item[1] for item in exiftool_batch]
-            _te0 = time.time()
-            batch_results = exiftool.batch_query(os_paths)
-            _t_exiftool_total += time.time() - _te0
+            nonlocal _t_geolocate_total, _t_results_wait, _t_worker_total
+            nonlocal worker_done_count
+            _trq0 = time.time()
+            while True:
+                try:
+                    packet = results_queue.get_nowait()
+                except queue.Empty:
+                    break
+                if packet.get("type") == "results":
+                    rows = packet.get("results", [])
+                    photo_data.extend(rows)
+                    file_counts.update(packet.get("file_counts", Counter()))
+                    processed_count += len(rows)
+                    _t_exiftool_total += packet.get("t_exiftool", 0.0)
+                    _t_hashing_total += packet.get("t_hashing", 0.0)
+                    _t_geolocate_total += packet.get("t_geolocate", 0.0)
+                elif packet.get("type") == "worker_done":
+                    stats = packet.get("stats", {})
+                    _worker_details.append(stats)
+                    _t_worker_total += stats.get("wall", 0.0)
+                    worker_done_count += 1
+            _t_results_wait += time.time() - _trq0
 
-            for out_path, os_path, key_path, size_bytes, mtime_ns in exiftool_batch:
-                date_taken, gps_lat, gps_lon = batch_results.get(
-                    os_path, (None, None, None)
-                )
-                location = None
-                if locate and gps_lat and gps_lon:
-                    location = geolocate(
-                        gps_lat,
-                        gps_lon,
-                        location_conn=location_conn,
-                        pending_counter=location_cache_pending,
-                    )
-                    if location and is_coordinate_string(location):
-                        location = None
-                _th0 = time.time()
-                content_hash = get_content_hash(
-                    key_path,
-                    size_bytes,
-                    mtime_ns,
+        def _update_progress_and_checkpoint():
+            nonlocal last_progress_time, last_save_time, _t_checkpoint_total
+            total_seen = cached_count + processed_count
+            current_time = time.time()
+            rate_tracker.record(current_time, total_seen)
+
+            if total_seen > 0 and (current_time - last_save_time) > 900:
+                _tc0 = time.time()
+                data_snapshot = list(photo_data)
+                _ckpt_ok = _safe_write_inventory(
+                    output,
+                    data_snapshot,
+                    inventory_root,
                     hash_options,
-                    hash_conn,
-                    hash_cache_pending,
-                    os_path=os_path,
+                    old_format,
+                    path_style,
+                    debug=debug,
+                    context="checkpoint",
                 )
-                _t_hashing_total += time.time() - _th0
-                photo_data.append(
-                    (
-                        out_path,
-                        date_taken or "",
-                        size_bytes,
-                        mtime_ns,
-                        gps_lat or "",
-                        gps_lon or "",
-                        location or "",
-                        content_hash,
+                _t_checkpoint_total += time.time() - _tc0
+                last_save_time = current_time
+                if not quiet:
+                    _clear_progress_line()
+                    if _ckpt_ok:
+                        print(f"[Checkpoint: {len(data_snapshot):,} files saved]")
+                if not _ckpt_ok:
+                    print(
+                        "Error: Checkpoint failed; stopping scan so you can "
+                        "fix the output path/disk/permissions and rerun."
                     )
-                )
-                processed_count += 1
+                    stop_event.set()
+                    return False
+
+            if not quiet and (current_time - last_progress_time) >= 2.0:
+                elapsed = current_time - start_time
+                rate = rate_tracker.rate()
+                rate_str = f"{rate:.0f} files/sec" if rate else "..."
+
+                if discovery_complete and total_files > 0:
+                    pct = total_seen / total_files * 100
+                    eta_str = _format_eta(total_files - total_seen, rate)
+                    eta_part = f" — ETA: {eta_str}" if eta_str else ""
+                    print(
+                        f"Processed {total_seen:,} / {total_files:,} ({pct:.1f}%) — "
+                        f"{rate_str}{eta_part} [{_format_duration(elapsed)}]",
+                        end="\r" if _IS_TTY else "\n",
+                    )
+                else:
+                    print(
+                        f"Discovering... {discovery.discovered:,} found | "
+                        f"Processed {total_seen:,} ({cached_count:,} cached) — "
+                        f"{rate_str} [{_format_duration(elapsed)}]",
+                        end="\r" if _IS_TTY else "\n",
+                    )
+                last_progress_time = current_time
+            return True
+
+        def _maybe_print_discovery_complete():
+            nonlocal discovery_complete, total_files
+            if not discovery_complete and discovery.done.is_set():
+                discovery_complete = True
+                total_files = discovery.total
+                if not quiet:
+                    _clear_progress_line()
+                    print(f"Discovery complete: {total_files:,} files found.")
+
+        def _record_blank_exif_batch(batch):
+            nonlocal processed_count, _t_hashing_total
+            blank_results = {item[1]: (None, None, None) for item in batch}
+            rows, counts, stats = _build_exiftool_rows(
+                batch,
+                blank_results,
+                locate,
+                location_conn,
+                location_cache_pending,
+                hash_options,
+                hash_conn,
+                hash_cache_pending,
+            )
+            photo_data.extend(rows)
+            file_counts.update(counts)
+            processed_count += len(rows)
+            _t_hashing_total += stats["t_hashing"]
+
+        def _enqueue_exiftool_batch():
+            if not exiftool_batch:
+                return True
+            batch = list(exiftool_batch)
             exiftool_batch.clear()
+            while True:
+                try:
+                    work_queue.put(batch, timeout=0.5)
+                    return True
+                except queue.Full:
+                    _drain_results()
+                    _maybe_print_discovery_complete()
+                    if not _update_progress_and_checkpoint():
+                        return False
+                    if not any(t.is_alive() for t in worker_threads):
+                        _log_worker_error(
+                            error_log,
+                            error_log_lock,
+                            f"Warning: all ExifTool workers stopped; recording {len(batch)} file(s) with blank EXIF.",
+                        )
+                        _record_blank_exif_batch(batch)
+                        return True
+
+        def _stop_workers(interrupt=False):
+            if interrupt:
+                stop_event.set()
+                for _ in worker_threads:
+                    try:
+                        work_queue.put_nowait(None)
+                    except queue.Full:
+                        pass
+            else:
+                for _ in worker_threads:
+                    work_queue.put(None)
+            timeout_seconds = 5 if interrupt else WORKER_SHUTDOWN_TIMEOUT_SECONDS
+            deadline = time.time() + timeout_seconds
+            while any(t.is_alive() for t in worker_threads):
+                for t in worker_threads:
+                    remaining = max(0.0, deadline - time.time())
+                    if remaining <= 0:
+                        alive = sum(1 for thread in worker_threads if thread.is_alive())
+                        if alive:
+                            print(
+                                f"Warning: {alive} ExifTool worker(s) did not exit within {timeout_seconds} seconds; abandoning.",
+                                file=sys.stderr,
+                            )
+                        return False
+                    t.join(timeout=min(0.2, remaining))
+                _drain_results()
+                if not interrupt:
+                    _update_progress_and_checkpoint()
+            _drain_results()
+            return True
 
         try:
             while True:
-                # --- Get next file from queue ---
+                _drain_results()
+                _maybe_print_discovery_complete()
+                if not _update_progress_and_checkpoint():
+                    _stop_workers(interrupt=True)
+                    cleanup_all()
+                    return False
+
                 try:
-                    item = file_queue.get(timeout=1.0)
+                    _td0 = time.time()
+                    item = file_queue.get(timeout=0.5)
+                    _t_dispatch_wait += time.time() - _td0
                 except queue.Empty:
-                    # No file ready — flush any pending exiftool batch
-                    _flush_exiftool_batch()
-                    if not quiet:
-                        current_time = time.time()
-                        if current_time - last_progress_time >= 2.0:
-                            elapsed = current_time - start_time
-                            total_seen = cached_count + processed_count
-                            rate = rate_tracker.rate()
-                            rate_str = f"{rate:.0f} files/sec" if rate else "..."
-                            print(
-                                f"Discovering... {discovery.discovered:,} found | "
-                                f"Processed {total_seen:,} ({cached_count:,} cached) — "
-                                f"{rate_str} [{_format_duration(elapsed)}]",
-                                end="\r" if _IS_TTY else "\n",
-                            )
-                            last_progress_time = current_time
+                    _t_dispatch_wait += time.time() - _td0
                     if discovery.done.is_set() and file_queue.empty():
-                        # Producer finished and queue is drained
                         if discovery.error is not None:
                             print(f"\nError during file discovery: {discovery.error}")
                             raise discovery.error from None
@@ -2430,8 +2763,6 @@ def run_scan(
                     continue
 
                 if item is None:
-                    # Sentinel: discovery finished — flush remaining batch
-                    _flush_exiftool_batch()
                     if discovery.error is not None:
                         if not quiet:
                             print(f"\nError during file discovery: {discovery.error}")
@@ -2441,15 +2772,6 @@ def run_scan(
                 file, is_symlink, prod_size, prod_mtime = item
                 basename = os.path.basename(file)
                 ext = os.path.splitext(basename)[1].lstrip(".").lower()
-
-                # Check if discovery just completed (for progress phase transition)
-                if not discovery_complete and discovery.done.is_set():
-                    discovery_complete = True
-                    total_files = discovery.total
-                    if not quiet:
-                        # Clear \r progress line, then print clean discovery summary
-                        _clear_progress_line()
-                        print(f"Discovery complete: {total_files:,} files found.")
 
                 try:
                     out_path = os.path.abspath(file)
@@ -2495,12 +2817,14 @@ def run_scan(
 
                         if locate and gps_lat and gps_lon:
                             if not location or is_coordinate_string(location):
+                                _tg0 = time.time()
                                 location = geolocate(
                                     gps_lat,
                                     gps_lon,
                                     location_conn=location_conn,
                                     pending_counter=location_cache_pending,
                                 )
+                                _t_geolocate_total += time.time() - _tg0
                                 cached_entry["location"] = location
 
                         _th0 = time.time()
@@ -2533,10 +2857,20 @@ def run_scan(
                         # Not cached — check if exiftool-eligible
                         if ext in EXIFTOOL_EXTENSIONS:
                             exiftool_batch.append(
-                                (out_path, fs_path, key_path, size_bytes, mtime_ns)
+                                (
+                                    out_path,
+                                    fs_path,
+                                    key_path,
+                                    size_bytes,
+                                    mtime_ns,
+                                    ext,
+                                )
                             )
                             if len(exiftool_batch) >= EXIFTOOL_BATCH_SIZE:
-                                _flush_exiftool_batch()
+                                if not _enqueue_exiftool_batch():
+                                    _stop_workers(interrupt=True)
+                                    cleanup_all()
+                                    return False
                         else:
                             # Non-media file: index with filesystem metadata only
                             _th0 = time.time()
@@ -2563,100 +2897,67 @@ def run_scan(
                                 )
                             )
                             processed_count += 1
-
-                    file_counts[ext] += 1
+                            file_counts[ext] += 1
+                    if (
+                        cached_entry
+                        and cached_entry["size_bytes"] == size_bytes
+                        and cached_entry["mtime_ns"] == mtime_ns
+                    ):
+                        file_counts[ext] += 1
 
                 except OSError as e:
                     error_log.write(f"Warning: Could not access '{file}': {str(e)}\n")
-                    if _check_drive_disconnect(
-                        e,
-                        output,
-                        photo_data,
-                        inventory_root,
-                        hash_options,
-                        old_format,
-                        cleanup_all,
-                        path_style=path_style,
+                    if any(
+                        err in str(e).lower()
+                        for err in [
+                            "no such file",
+                            "input/output error",
+                            "stale file handle",
+                        ]
                     ):
-                        exiftool.stop()
-                        return False
+                        _stop_workers(interrupt=True)
+                        _drain_results()
+                        if _check_drive_disconnect(
+                            e,
+                            output,
+                            photo_data,
+                            inventory_root,
+                            hash_options,
+                            old_format,
+                            cleanup_all,
+                            path_style=path_style,
+                        ):
+                            return False
                     continue
 
-                # --- Progress and checkpointing ---
-                total_seen = cached_count + processed_count
-                current_time = time.time()
-
-                # Record rate sample
-                rate_tracker.record(current_time, total_seen)
-
-                # Checkpoint every 15 minutes
-                if total_seen > 0 and (current_time - last_save_time) > 900:
-                    _tc0 = time.time()
-                    # Alan 5/3/26 - Use _safe_write_inventory so a transient
-                    # write failure (drive removed, dir vanished, disk full,
-                    # ACL change mid-scan) prints a friendly message instead
-                    # of a Python traceback.
-                    _ckpt_ok = _safe_write_inventory(
-                        output,
-                        photo_data,
-                        inventory_root,
-                        hash_options,
-                        old_format,
-                        path_style,
-                        debug=debug,
-                        context="checkpoint",
-                    )
-                    _t_checkpoint_total += time.time() - _tc0
-                    last_save_time = current_time
-                    if not quiet:
-                        _clear_progress_line()
-                        if _ckpt_ok:
-                            print(f"[Checkpoint: {len(photo_data):,} files saved]")
-                    # Alan 5/4/26 - If the checkpoint failed, stop the scan
-                    # rather than continuing with unsaved data for hours.
-                    # The final write would just hit the same error, and
-                    # the user needs to fix the underlying issue (bad path,
-                    # full disk, revoked permissions) before any rerun.
-                    if not _ckpt_ok:
+            if not _enqueue_exiftool_batch():
+                _stop_workers(interrupt=True)
+                cleanup_all()
+                return False
+            workers_finished = _stop_workers(interrupt=False)
+            if workers_finished:
+                done_deadline = time.time() + 10
+                while worker_done_count < worker_count:
+                    _drain_results()
+                    if worker_done_count >= worker_count:
+                        break
+                    if time.time() >= done_deadline:
+                        missing = worker_count - worker_done_count
                         print(
-                            "Error: Checkpoint failed; stopping scan so you can "
-                            "fix the output path/disk/permissions and rerun."
+                            f"Warning: missing {missing} ExifTool worker completion packet(s); continuing.",
+                            file=sys.stderr,
                         )
-                        try:
-                            exiftool.stop()
-                        except Exception:
-                            pass
-                        cleanup_all()
-                        return False
+                        break
+                    time.sleep(0.05)
 
-                # Progress line every 2 seconds
-                if not quiet and (current_time - last_progress_time) >= 2.0:
-                    elapsed = current_time - start_time
-                    rate = rate_tracker.rate()
-                    rate_str = f"{rate:.0f} files/sec" if rate else "..."
-
-                    if discovery_complete and total_files > 0:
-                        # Phase 2: show percent and ETA
-                        pct = total_seen / total_files * 100
-                        eta_str = _format_eta(total_files - total_seen, rate)
-                        eta_part = f" — ETA: {eta_str}" if eta_str else ""
-                        print(
-                            f"Processed {total_seen:,} / {total_files:,} ({pct:.1f}%) — "
-                            f"{rate_str}{eta_part} [{_format_duration(elapsed)}]",
-                            end="\r" if _IS_TTY else "\n",
-                        )
-                    else:
-                        # Phase 1: discovery still running
-                        print(
-                            f"Discovering... {discovery.discovered:,} found | "
-                            f"Processed {total_seen:,} ({cached_count:,} cached) — "
-                            f"{rate_str} [{_format_duration(elapsed)}]",
-                            end="\r" if _IS_TTY else "\n",
-                        )
-                    last_progress_time = current_time
-
+        except Exception:
+            _stop_workers(interrupt=True)
+            _drain_results()
+            raise
         except KeyboardInterrupt:
             interrupted = True
+            _stop_workers(interrupt=True)
+            _drain_results()
             print(
                 f"\n\nInterrupted! Saving progress ({len(photo_data):,} files processed so far)..."
             )
@@ -2666,7 +2967,7 @@ def run_scan(
             try:
                 if _safe_write_inventory(
                     output,
-                    photo_data,
+                    list(photo_data),
                     inventory_root,
                     hash_options,
                     old_format,
@@ -2683,8 +2984,6 @@ def run_scan(
                 "The scan will pick up where it left off using the saved inventory as cache."
             )
 
-        exiftool.stop()
-
     # Wait for producer thread to finish (should already be done)
     producer.join(timeout=5)
 
@@ -2696,6 +2995,7 @@ def run_scan(
     if total_seen == 0:
         if not quiet:
             print("No files found.")
+        cleanup_all()
         return True
 
     if not quiet:
@@ -2752,7 +3052,15 @@ def run_scan(
         perf_stats["t_cache_lookup"] = _t_cache_lookup_total
         perf_stats["t_exiftool"] = _t_exiftool_total
         perf_stats["t_hashing"] = _t_hashing_total
+        perf_stats["t_geolocate"] = _t_geolocate_total
         perf_stats["t_checkpoints"] = _t_checkpoint_total
+        perf_stats["t_dispatch_wait"] = _t_dispatch_wait
+        perf_stats["t_results_wait"] = _t_results_wait
+        perf_stats["t_worker_total"] = _t_worker_total
+        perf_stats["worker_details"] = sorted(
+            _worker_details, key=lambda item: item.get("worker_id", 0)
+        )
+        perf_stats["worker_count"] = worker_count
         perf_stats["t_write"] = _t_write
         perf_stats["files_total"] = total_seen
         perf_stats["files_cached"] = cached_count
@@ -2766,24 +3074,56 @@ def _print_perf_summary(label, stats):
     wall = stats.get("wall_total", 0)
     if wall <= 0:
         return
+    worker_count = stats.get("worker_count", 1)
     print(f"\n--- Timing breakdown (overlapping; not additive): {label} ---")
     items = [
-        ("Inventory cache load", stats.get("t_cache_load", 0)),
-        ("Discovery (wall)", stats.get("t_discovery_wall", 0)),
-        ("  scandir walk", stats.get("t_discovery_walk", 0)),
-        ("  queue put-wait", stats.get("t_discovery_queue_wait", 0)),
-        ("realpath() calls", stats.get("t_realpath", 0)),
-        ("stat() calls", stats.get("t_stat", 0)),
-        ("TSV cache lookups", stats.get("t_cache_lookup", 0)),
-        ("ExifTool batches", stats.get("t_exiftool", 0)),
-        ("Content hashing", stats.get("t_hashing", 0)),
-        ("Checkpoints", stats.get("t_checkpoints", 0)),
-        ("Final write", stats.get("t_write", 0)),
+        ("Inventory cache load", stats.get("t_cache_load", 0), True),
+        ("Discovery (wall)", stats.get("t_discovery_wall", 0), True),
+        ("  scandir walk", stats.get("t_discovery_walk", 0), True),
+        ("  queue put-wait", stats.get("t_discovery_queue_wait", 0), True),
+        ("realpath() calls", stats.get("t_realpath", 0), True),
+        ("stat() calls", stats.get("t_stat", 0), True),
+        ("TSV cache lookups", stats.get("t_cache_lookup", 0), True),
+        ("Dispatch wait", stats.get("t_dispatch_wait", 0), True),
+        ("Results drain", stats.get("t_results_wait", 0), True),
+        (f"ExifTool ({worker_count}w sum)", stats.get("t_exiftool", 0), False),
+        (
+            f"Content hashing ({worker_count}w sum)",
+            stats.get("t_hashing", 0),
+            False,
+        ),
+        (f"Geolocation ({worker_count}w sum)", stats.get("t_geolocate", 0), False),
+        ("Checkpoints", stats.get("t_checkpoints", 0), True),
+        ("Final write", stats.get("t_write", 0), True),
     ]
-    for name, secs in items:
-        pct = secs / wall * 100 if wall else 0
-        print(f"  {name:<22s} {secs:7.2f}s  ({pct:5.1f}% of wall)")
-    print(f"  {'Wall total':<22s} {wall:7.2f}s")
+    for name, secs, show_pct in items:
+        if show_pct:
+            pct = secs / wall * 100 if wall else 0
+            print(f"  {name:<26s} {secs:7.2f}s  ({pct:5.1f}% of wall)")
+        else:
+            print(f"  {name:<26s} {secs:7.2f}s  (sum across workers)")
+    print(f"  {'Wall total':<26s} {wall:7.2f}s")
+    worker_details = stats.get("worker_details") or []
+    worker_active_total = sum(item.get("t_active", 0) for item in worker_details)
+    if worker_active_total:
+        print(
+            f"  {'Worker active total':<26s} {worker_active_total:7.2f}s  (parallel; sum exceeds wall by design)"
+        )
+    if worker_details:
+        print("  Per-worker:")
+        for item in worker_details:
+            print(
+                "    "
+                f"#{item.get('worker_id', 0):<2d} "
+                f"wall={item.get('wall', 0):.2f}s "
+                f"active={item.get('t_active', 0):.2f}s "
+                f"exif={item.get('t_exiftool', 0):.2f}s "
+                f"hash={item.get('t_hashing', 0):.2f}s "
+                f"geo={item.get('t_geolocate', 0):.2f}s "
+                f"push={item.get('t_queue_push', 0):.2f}s "
+                f"files={item.get('files', 0):,} "
+                f"errors={item.get('errors', 0)}"
+            )
     total = stats.get("files_total", 0)
     cached = stats.get("files_cached", 0)
     processed = stats.get("files_processed", 0)
@@ -3142,6 +3482,7 @@ Options:
   --hash {sample,full,off}  Hashing mode (default: off). Use --hash sample to enable.
   --hash-cache PATH        Path to SQLite hash cache.
   --no-hash-cache          Disable hash cache.
+  --workers N       Number of parallel ExifTool workers (default: 4).
   --add-hashes             Fill in missing hashes for an existing inventory file.
   --old-format       Write legacy line-based output (./path: YYYY:MM:DD HH:MM:SS) without hashes.
   --save             Save the current scan configuration for later use.
@@ -3264,6 +3605,13 @@ For more details on a specific option, you can also use:
         help="Print a performance timing summary after each scan.",
     )
     parser.add_argument(
+        "--workers",
+        type=int,
+        default=4,
+        metavar="N",
+        help="Number of parallel ExifTool worker processes (default: 4).",
+    )
+    parser.add_argument(
         "--linux",
         action="store_const",
         dest="path_style",
@@ -3363,6 +3711,7 @@ For more details on a specific option, you can also use:
             "hash_exts": args.hash_exts,
             "old_format": args.old_format,
             "path_style": args.path_style,
+            "workers": _clamp_worker_count(args.workers),
         }
 
         config = load_config()
@@ -3429,6 +3778,7 @@ For more details on a specific option, you can also use:
                 perf_stats=scan_perf,
                 path_style=args.path_style,
                 raw_output=output,
+                workers=args.workers,
             )
             if scan_perf and (
                 # Print a performance summary if the run takes more than 1000 seconds
@@ -3490,6 +3840,7 @@ For more details on a specific option, you can also use:
                     old_format=flags.get("old_format", False),
                     perf_stats=scan_perf,
                     path_style=flags.get("path_style", "auto"),
+                    workers=flags.get("workers", 4),
                 )
                 if ok is False:
                     any_scan_failed = True
@@ -3537,6 +3888,7 @@ For more details on a specific option, you can also use:
         perf_stats=scan_perf,
         path_style=args.path_style,
         raw_output=output,
+        workers=args.workers,
     )
     if scan_perf and (args.debugperformance or scan_perf.get("wall_total", 0) >= 1000):
         _print_perf_summary(directory_abs, scan_perf)

--- a/findphotodates.py
+++ b/findphotodates.py
@@ -7,6 +7,7 @@
 from pathlib import Path
 import hashlib
 import os
+import stat
 import sys
 import subprocess
 import argparse
@@ -626,7 +627,29 @@ def is_supported_file(filename, extensions):
     return any(filename.lower().endswith(f".{ext}") for ext in extensions)
 
 
-def find_files(directory, extensions):
+def _is_windows_reparse_point_dir(entry):
+    """Return True if this DirEntry is a Windows directory reparse point
+    (junction, directory symlink, or other directory-like reparse target).
+
+    Callers should already have confirmed the entry is a directory
+    (entry.is_dir(follow_symlinks=False) == True) before invoking this — we
+    only need to decide whether that directory is a reparse point we must
+    refuse to recurse into.
+
+    Always False on non-Windows platforms, where st_file_attributes is absent.
+    """
+    try:
+        st = entry.stat(follow_symlinks=False)
+    except (PermissionError, OSError):
+        return False
+    attrs = getattr(st, "st_file_attributes", None)
+    if attrs is None:
+        return False
+    reparse_bit = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+    return bool(attrs & reparse_bit)
+
+
+def find_files(directory, extensions, debug=False):
     """Recursively find all files with the specified extensions using os.scandir().
 
     Yields (filepath, is_symlink, size_bytes, mtime_ns) tuples.
@@ -646,9 +669,24 @@ def find_files(directory, extensions):
         for entry in scan_it:
             try:
                 is_link = entry.is_symlink()
-                if entry.is_dir(follow_symlinks=False):
+                is_dir_no_follow = entry.is_dir(follow_symlinks=False)
+                if is_dir_no_follow:
+                    # Alan 5/3/26 - Skip Windows reparse-point *directories*
+                    # (NTFS junctions and directory symlinks) to avoid
+                    # traversal loops such as
+                    # C:\ProgramData\Application Data -> C:\ProgramData.
+                    # Only checked for directories so ordinary reparse-point
+                    # files (e.g. OneDrive cloud placeholders, file symlinks)
+                    # are still indexed normally.
+                    if _is_windows_reparse_point_dir(entry):
+                        if debug:
+                            print(
+                                f"Debug: Skipping reparse-point directory: {entry.path}",
+                                file=sys.stderr,
+                            )
+                        continue
                     # Real directory — recurse
-                    yield from find_files(entry.path, extensions)
+                    yield from find_files(entry.path, extensions, debug=debug)
                 elif is_link and entry.is_dir(follow_symlinks=True):
                     # Symlinked directory — skip recursion to avoid
                     # duplicate traversal and symlink loops
@@ -1595,7 +1633,7 @@ class _DiscoveryState:
         self.t_queue_wait = 0.0  # time spent blocked on queue.put()
 
 
-def _discovery_producer(file_queue, directory, extensions, state):
+def _discovery_producer(file_queue, directory, extensions, state, debug=False):
     """Producer thread: walk directory, enqueue file tuples, signal done.
 
     Each queued item is (filepath, is_symlink, size_bytes, mtime_ns).
@@ -1611,7 +1649,7 @@ def _discovery_producer(file_queue, directory, extensions, state):
         count = 0
         t_walk = 0.0
         t_queue = 0.0
-        it = iter(find_files(directory, extensions))
+        it = iter(find_files(directory, extensions, debug=debug))
         while True:
             tw0 = time.monotonic()
             try:
@@ -1815,7 +1853,7 @@ def run_scan(
     discovery = _DiscoveryState()
     producer = threading.Thread(
         target=_discovery_producer,
-        args=(file_queue, directory, extensions, discovery),
+        args=(file_queue, directory, extensions, discovery, debug),
         daemon=True,
     )
     producer.start()

--- a/findphotodates.py
+++ b/findphotodates.py
@@ -1250,6 +1250,20 @@ def geolocate(lat, lon, location_conn=None, pending_counter=None):
         return cached_location
 
     with _geolocate_lock:
+        cached_location = _coord_cache.get(cache_key)
+        if cached_location:
+            return cached_location
+
+        cached_location = get_cached_location(
+            location_conn,
+            lat_rounded,
+            lon_rounded,
+            LOCATION_CACHE_PRECISION,
+        )
+        if cached_location:
+            _coord_cache[cache_key] = cached_location
+            return cached_location
+
         # Rate limiting: wait at least 1 second since last request
         current_time = time.time()
         time_since_last = current_time - _last_geolocate_time
@@ -1316,16 +1330,15 @@ def geolocate(lat, lon, location_conn=None, pending_counter=None):
             _last_geolocate_time = time.time()
             return f"{lat_float}, {lon_float}"
 
-    with _geolocate_lock:
         _coord_cache[cache_key] = location
-    put_cached_location(
-        location_conn,
-        lat_rounded,
-        lon_rounded,
-        LOCATION_CACHE_PRECISION,
-        location,
-        pending_counter=pending_counter,
-    )
+        put_cached_location(
+            location_conn,
+            lat_rounded,
+            lon_rounded,
+            LOCATION_CACHE_PRECISION,
+            location,
+            pending_counter=pending_counter,
+        )
     return location
 
 
@@ -2338,7 +2351,20 @@ def _exiftool_worker(
             try:
                 if exiftool is None:
                     exiftool = ExifToolPersistent()
-                    exiftool.start()
+                    try:
+                        exiftool.start()
+                    except Exception as e:
+                        worker_stats["errors"] += 1
+                        results_queue.put(
+                            {
+                                "type": "fatal_error",
+                                "message": (
+                                    f"Error: ExifTool worker {worker_id} failed to start: {e}"
+                                ),
+                            }
+                        )
+                        stop_event.set()
+                        return
                 fast2_batch = [
                     item for item in batch if item[5] in SIZE_FILTERED_IMAGE_EXTENSIONS
                 ]
@@ -2585,6 +2611,7 @@ def run_scan(
         error_log_lock = threading.Lock()
         worker_threads = []
         worker_done_count = 0
+        fatal_worker_error = None
 
         for worker_id in range(1, worker_count + 1):
             t = threading.Thread(
@@ -2618,7 +2645,7 @@ def run_scan(
         def _drain_results():
             nonlocal processed_count, _t_exiftool_total, _t_hashing_total
             nonlocal _t_geolocate_total, _t_results_wait, _t_worker_total
-            nonlocal worker_done_count
+            nonlocal worker_done_count, fatal_worker_error
             _trq0 = time.time()
             while True:
                 try:
@@ -2638,7 +2665,14 @@ def run_scan(
                     _worker_details.append(stats)
                     _t_worker_total += stats.get("wall", 0.0)
                     worker_done_count += 1
+                elif packet.get("type") == "fatal_error":
+                    if fatal_worker_error is None:
+                        fatal_worker_error = packet.get(
+                            "message", "Error: ExifTool worker failed."
+                        )
+                        print(fatal_worker_error, file=sys.stderr)
             _t_results_wait += time.time() - _trq0
+            return fatal_worker_error is None
 
         def _update_progress_and_checkpoint():
             nonlocal last_progress_time, last_save_time, _t_checkpoint_total
@@ -2762,7 +2796,8 @@ def run_scan(
                     work_queue.put(batch, timeout=0.5)
                     return True
                 except queue.Full:
-                    _drain_results()
+                    if not _drain_results():
+                        return False
                     _maybe_print_discovery_complete()
                     if not _update_progress_and_checkpoint():
                         return False
@@ -2808,7 +2843,10 @@ def run_scan(
 
         try:
             while True:
-                _drain_results()
+                if not _drain_results():
+                    _stop_workers(interrupt=True)
+                    cleanup_all()
+                    return False
                 _maybe_print_discovery_complete()
                 if not _update_progress_and_checkpoint():
                     _stop_workers(interrupt=True)
@@ -3001,20 +3039,35 @@ def run_scan(
                 cleanup_all()
                 return False
             workers_finished = _stop_workers(interrupt=False)
-            if workers_finished:
-                done_deadline = time.time() + 10
-                while worker_done_count < worker_count:
+            if fatal_worker_error is not None:
+                _stop_workers(interrupt=True)
+                _drain_results()
+                cleanup_all()
+                return False
+            if not workers_finished:
+                _stop_workers(interrupt=True)
+                _drain_results()
+                cleanup_all()
+                return False
+            done_deadline = time.time() + 10
+            while worker_done_count < worker_count:
+                if not _drain_results():
+                    _stop_workers(interrupt=True)
+                    cleanup_all()
+                    return False
+                if worker_done_count >= worker_count:
+                    break
+                if time.time() >= done_deadline:
+                    missing = worker_count - worker_done_count
+                    print(
+                        f"Warning: missing {missing} ExifTool worker completion packet(s); failing scan.",
+                        file=sys.stderr,
+                    )
+                    _stop_workers(interrupt=True)
                     _drain_results()
-                    if worker_done_count >= worker_count:
-                        break
-                    if time.time() >= done_deadline:
-                        missing = worker_count - worker_done_count
-                        print(
-                            f"Warning: missing {missing} ExifTool worker completion packet(s); continuing.",
-                            file=sys.stderr,
-                        )
-                        break
-                    time.sleep(0.05)
+                    cleanup_all()
+                    return False
+                time.sleep(0.05)
 
         except Exception:
             _stop_workers(interrupt=True)
@@ -3548,7 +3601,7 @@ Options:
   --hash {sample,full,off}  Hashing mode (default: off). Use --hash sample to enable.
   --hash-cache PATH        Path to SQLite hash cache.
   --no-hash-cache          Disable hash cache.
-  --workers N       Number of parallel ExifTool workers (default: 4).
+  --workers N       Number of parallel ExifTool worker threads (default: 4).
   --min-image-size BYTES  Skip ExifTool for tiny JPG/JPEG/PNG/WebP images (default: 100,000; 0 disables).
   --add-hashes             Fill in missing hashes for an existing inventory file.
   --old-format       Write legacy line-based output (./path: YYYY:MM:DD HH:MM:SS) without hashes.
@@ -3676,7 +3729,7 @@ For more details on a specific option, you can also use:
         type=int,
         default=4,
         metavar="N",
-        help="Number of parallel ExifTool worker processes (default: 4).",
+        help="Number of parallel ExifTool worker threads (default: 4).",
     )
     parser.add_argument(
         "--min-image-size",

--- a/tests/test_exiftool_unicode.py
+++ b/tests/test_exiftool_unicode.py
@@ -1,0 +1,103 @@
+"""Regression tests for Unicode-safe ExifTool subprocess pipes.
+
+Reproduces the U+202F (narrow no-break space) crash on Windows where Python's
+default cp1252 stdin encoding raised UnicodeEncodeError.  We don't actually
+spawn exiftool here — we monkeypatch subprocess.Popen so the test runs on any
+platform without depending on exiftool being installed.
+"""
+
+import io
+import subprocess
+
+import findphotodates
+
+
+class _FakeProc:
+    def __init__(self, *args, **kwargs):
+        self._popen_args = args
+        self._popen_kwargs = kwargs
+        self.stdin = io.StringIO()
+        self.stdout = io.StringIO("{ready}\n")
+
+    def kill(self):
+        pass
+
+    def wait(self, timeout=None):
+        return 0
+
+
+def test_popen_uses_utf8_and_filename_charset(monkeypatch):
+    captured = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return _FakeProc(cmd, **kwargs)
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    et = findphotodates.ExifToolPersistent()
+    et.start()
+
+    assert captured["kwargs"].get("encoding") == "utf-8"
+    assert captured["kwargs"].get("errors") == "surrogateescape"
+    cmd = captured["cmd"]
+    # ExifTool must be told that filenames on the argfile pipe are UTF-8,
+    # otherwise on Windows it interprets them as the active code page.
+    assert "-charset" in cmd
+    assert "filename=UTF8" in cmd
+    assert "-stay_open" in cmd
+
+
+def test_send_and_read_survives_unicode_encode_error(monkeypatch):
+    class _BadStdinProc:
+        def __init__(self):
+            self.stdout = io.StringIO("")
+            self.killed = False
+
+            class _Stdin:
+                def write(self_inner, _data):
+                    raise UnicodeEncodeError("charmap", " ", 0, 1, "bad")
+
+                def flush(self_inner):
+                    pass
+
+            self.stdin = _Stdin()
+
+        def kill(self):
+            self.killed = True
+
+        def wait(self, timeout=None):
+            return 0
+
+    et = findphotodates.ExifToolPersistent()
+    et._proc = _BadStdinProc()
+
+    # Should not raise — must return None so callers can fall back gracefully.
+    result = et._send_and_read(["-json", "/tmp/unicode name.jpg"])
+    assert result is None
+    assert et._proc is None
+
+
+def test_unicode_filename_roundtrip_in_batch(monkeypatch):
+    """A filename containing U+202F must be processable through batch_query
+    without raising — even when the underlying exiftool call yields nothing.
+    """
+
+    class _EmptyProc:
+        def __init__(self):
+            self.stdin = io.StringIO()
+            self.stdout = io.StringIO("[]\n{ready}\n")
+
+        def kill(self):
+            pass
+
+        def wait(self, timeout=None):
+            return 0
+
+    et = findphotodates.ExifToolPersistent()
+    et._proc = _EmptyProc()
+
+    path = "/tmp/unicode space.jpg"
+    out = et.batch_query([path])
+    assert out == {path: (None, None, None)}

--- a/tests/test_location_cache.py
+++ b/tests/test_location_cache.py
@@ -1,4 +1,5 @@
 import json
+import threading
 from pathlib import Path
 
 import pytest
@@ -274,6 +275,44 @@ def test_no_location_cache_still_uses_in_memory_cache(monkeypatch):
 
     assert fpd.geolocate("37.801", "-122.271").startswith("Oakland")
     assert fpd.geolocate("37.802", "-122.272").startswith("Oakland")
+    assert calls["count"] == 1
+
+
+def test_concurrent_geolocate_rechecks_cache_inside_lock(monkeypatch):
+    calls = {"count": 0}
+    urlopen_entered = threading.Event()
+    release_urlopen = threading.Event()
+    errors = []
+    results = []
+
+    def fake_urlopen(req, timeout):
+        calls["count"] += 1
+        urlopen_entered.set()
+        release_urlopen.wait(timeout=2)
+        return FakeResponse({"display_name": "Cached Place"})
+
+    monkeypatch.setattr(fpd.urllib.request, "urlopen", fake_urlopen)
+
+    def call_geolocate(lat, lon):
+        try:
+            results.append(fpd.geolocate(lat, lon))
+        except Exception as e:
+            errors.append(e)
+
+    first = threading.Thread(target=call_geolocate, args=("37.801", "-122.271"))
+    second = threading.Thread(target=call_geolocate, args=("37.802", "-122.272"))
+
+    first.start()
+    assert urlopen_entered.wait(timeout=2)
+    second.start()
+    release_urlopen.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert not errors
+    assert sorted(results) == ["Cached Place", "Cached Place"]
     assert calls["count"] == 1
 
 

--- a/tests/test_location_cache.py
+++ b/tests/test_location_cache.py
@@ -1,0 +1,333 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import findphotodates as fpd
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+@pytest.fixture(autouse=True)
+def reset_geolocation_state():
+    saved_cache = dict(fpd._coord_cache)
+    saved_time = fpd._last_geolocate_time
+    fpd._coord_cache.clear()
+    fpd._last_geolocate_time = 0
+    yield
+    fpd._coord_cache.clear()
+    fpd._coord_cache.update(saved_cache)
+    fpd._last_geolocate_time = saved_time
+
+
+def _write_inventory(path, rows):
+    path.write_text(
+        "\n".join(
+            [
+                fpd.TSV_HEADER,
+                "\t".join(fpd.TSV_COLUMNS),
+                *rows,
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_photo(directory, name):
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    path.write_bytes(b"photo")
+    return path
+
+
+def _patch_exiftool(monkeypatch, responses_by_name):
+    class FakeExifToolPersistent:
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def batch_query(self, filepaths):
+            return {
+                fp: responses_by_name.get(Path(fp).name, (None, None, None))
+                for fp in filepaths
+            }
+
+    monkeypatch.setattr(fpd, "ExifToolPersistent", FakeExifToolPersistent)
+
+
+def test_load_cache_primes_geolocation_cache_from_resolved_locations(tmp_path):
+    inventory = tmp_path / "inventory.tsv"
+    _write_inventory(
+        inventory,
+        [
+            "/photos/a.jpg\t\t1\t2\t37.871\t-122.273\tAlbany, Alameda County, California, United States\t",
+            "/photos/b.jpg\t\t1\t2\t37.881\t-122.283\t37.881, -122.283\t",
+        ],
+    )
+
+    fpd.load_cache(str(inventory))
+
+    assert fpd._coord_cache[(37.87, -122.27)].startswith("Albany")
+    assert (37.88, -122.28) not in fpd._coord_cache
+
+
+def test_run_scan_reuses_sqlite_location_cache_across_tsvs(tmp_path, monkeypatch):
+    _write_photo(tmp_path / "drive_a", "a.jpg")
+    _write_photo(tmp_path / "drive_b", "b.jpg")
+    _patch_exiftool(
+        monkeypatch,
+        {
+            "a.jpg": ("2024:01:01 12:00:00", "37.871", "-122.273"),
+            "b.jpg": ("2024:01:01 12:00:00", "37.872", "-122.274"),
+        },
+    )
+
+    calls = {"count": 0}
+
+    def fake_urlopen(req, timeout):
+        calls["count"] += 1
+        return FakeResponse(
+            {
+                "address": {
+                    "city": "Albany",
+                    "county": "Alameda County",
+                    "state": "California",
+                    "country": "United States",
+                }
+            }
+        )
+
+    monkeypatch.setattr(fpd.urllib.request, "urlopen", fake_urlopen)
+
+    location_options = fpd.parse_location_args(
+        location_cache_path=str(tmp_path / "location_cache.sqlite")
+    )
+    hash_options = fpd.parse_hash_args(hash_mode="off")
+
+    assert fpd.run_scan(
+        str(tmp_path / "drive_a"),
+        str(tmp_path / "a.tsv"),
+        {"jpg"},
+        locate=True,
+        quiet=True,
+        hash_options=hash_options,
+        location_options=location_options,
+    )
+    assert calls["count"] == 1
+
+    fpd._coord_cache.clear()
+
+    assert fpd.run_scan(
+        str(tmp_path / "drive_b"),
+        str(tmp_path / "b.tsv"),
+        {"jpg"},
+        locate=True,
+        quiet=True,
+        hash_options=hash_options,
+        location_options=location_options,
+    )
+    assert calls["count"] == 1
+
+
+def test_run_scan_uses_tsv_prime_when_location_cache_disabled(
+    tmp_path, monkeypatch
+):
+    inventory = tmp_path / "drive_a.tsv"
+    _write_inventory(
+        inventory,
+        [
+            "/mnt/drive_a/a.jpg\t\t1\t2\t37.871\t-122.273\tAlbany, Alameda County, California, United States\t",
+        ],
+    )
+    fpd.load_cache(str(inventory))
+
+    _write_photo(tmp_path / "drive_b", "b.jpg")
+    _patch_exiftool(
+        monkeypatch,
+        {
+            "b.jpg": ("2024:01:01 12:00:00", "37.872", "-122.274"),
+        },
+    )
+
+    calls = {"count": 0}
+
+    def fake_urlopen(req, timeout):
+        calls["count"] += 1
+        return FakeResponse({"display_name": "Should Not Be Used"})
+
+    def fail_open_location_cache(*args, **kwargs):
+        raise AssertionError("--no-location-cache should not open SQLite")
+
+    monkeypatch.setattr(fpd.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(fpd, "open_location_cache", fail_open_location_cache)
+
+    assert fpd.run_scan(
+        str(tmp_path / "drive_b"),
+        str(tmp_path / "drive_b.tsv"),
+        {"jpg"},
+        locate=True,
+        quiet=True,
+        hash_options=fpd.parse_hash_args(hash_mode="off"),
+        location_options=fpd.parse_location_args(no_location_cache=True),
+    )
+
+    assert calls["count"] == 0
+    assert "Albany, Alameda County, California, United States" in (
+        tmp_path / "drive_b.tsv"
+    ).read_text(encoding="utf-8")
+
+
+def test_tsv_primed_geolocate_does_not_call_nominatim(tmp_path, monkeypatch):
+    inventory = tmp_path / "inventory.tsv"
+    _write_inventory(
+        inventory,
+        [
+            "/photos/a.jpg\t\t1\t2\t37.871\t-122.273\tAlbany, Alameda County, California, United States\t",
+        ],
+    )
+    fpd.load_cache(str(inventory))
+
+    def fail_urlopen(*args, **kwargs):
+        raise AssertionError("Nominatim should not be called")
+
+    monkeypatch.setattr(fpd.urllib.request, "urlopen", fail_urlopen)
+
+    assert fpd.geolocate("37.872", "-122.274").startswith("Albany")
+
+
+def test_sqlite_location_cache_is_reused_without_nominatim(tmp_path, monkeypatch):
+    cache_path = tmp_path / "location_cache.sqlite"
+    conn = fpd.open_location_cache(str(cache_path))
+    calls = {"count": 0}
+
+    def fake_urlopen(req, timeout):
+        calls["count"] += 1
+        return FakeResponse(
+            {
+                "address": {
+                    "city": "San Francisco",
+                    "county": "San Francisco County",
+                    "state": "California",
+                    "country": "United States",
+                }
+            }
+        )
+
+    monkeypatch.setattr(fpd.urllib.request, "urlopen", fake_urlopen)
+
+    location = fpd.geolocate("37.771", "-122.419", location_conn=conn)
+    assert location == "San Francisco, San Francisco County, California, United States"
+    assert calls["count"] == 1
+    conn.commit()
+    conn.close()
+
+    fpd._coord_cache.clear()
+    conn = fpd.open_location_cache(str(cache_path))
+
+    def fail_urlopen(*args, **kwargs):
+        raise AssertionError("Nominatim should not be called")
+
+    monkeypatch.setattr(fpd.urllib.request, "urlopen", fail_urlopen)
+
+    assert (
+        fpd.geolocate("37.772", "-122.418", location_conn=conn)
+        == "San Francisco, San Francisco County, California, United States"
+    )
+    conn.close()
+
+
+def test_no_location_cache_still_uses_in_memory_cache(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_urlopen(req, timeout):
+        calls["count"] += 1
+        return FakeResponse(
+            {
+                "address": {
+                    "city": "Oakland",
+                    "county": "Alameda County",
+                    "state": "California",
+                    "country": "United States",
+                }
+            }
+        )
+
+    monkeypatch.setattr(fpd.urllib.request, "urlopen", fake_urlopen)
+
+    assert fpd.geolocate("37.801", "-122.271").startswith("Oakland")
+    assert fpd.geolocate("37.802", "-122.272").startswith("Oakland")
+    assert calls["count"] == 1
+
+
+def test_default_cache_dir_platforms(monkeypatch, tmp_path):
+    monkeypatch.setattr(fpd.platform, "system", lambda: "Linux")
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg"))
+    assert fpd._default_cache_dir() == tmp_path / "xdg" / "findphotodates"
+
+    monkeypatch.setattr(fpd.platform, "system", lambda: "Windows")
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+    assert (
+        fpd._default_cache_dir()
+        == tmp_path / "local" / "findphotodates" / "Cache"
+    )
+
+
+def test_windows_hash_cache_migration_moves_once(monkeypatch, tmp_path, capsys):
+    home = tmp_path / "home"
+    old_dir = home / ".cache" / "findphotodates"
+    old_dir.mkdir(parents=True)
+    old_path = old_dir / "hash_cache.sqlite"
+    old_path.write_text("hash", encoding="utf-8")
+    (old_dir / "hash_cache.sqlite-wal").write_text("wal", encoding="utf-8")
+
+    new_path = tmp_path / "local" / "findphotodates" / "Cache" / "hash_cache.sqlite"
+
+    monkeypatch.setattr(fpd.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(fpd.Path, "home", staticmethod(lambda: home))
+    monkeypatch.setattr(fpd, "DEFAULT_HASH_CACHE_PATH", new_path)
+
+    assert fpd.migrate_default_hash_cache() is True
+    assert "Moved existing hash cache" in capsys.readouterr().out
+    assert not old_path.exists()
+    assert new_path.read_text(encoding="utf-8") == "hash"
+    assert Path(str(new_path) + "-wal").read_text(encoding="utf-8") == "wal"
+
+    assert fpd.migrate_default_hash_cache() is False
+    assert capsys.readouterr().out == ""
+
+
+def test_windows_hash_cache_migration_ignores_sidecar_without_main_db(
+    monkeypatch, tmp_path, capsys
+):
+    home = tmp_path / "home"
+    old_dir = home / ".cache" / "findphotodates"
+    old_dir.mkdir(parents=True)
+    old_wal = old_dir / "hash_cache.sqlite-wal"
+    old_wal.write_text("wal", encoding="utf-8")
+
+    new_path = tmp_path / "local" / "findphotodates" / "Cache" / "hash_cache.sqlite"
+
+    monkeypatch.setattr(fpd.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(fpd.Path, "home", staticmethod(lambda: home))
+    monkeypatch.setattr(fpd, "DEFAULT_HASH_CACHE_PATH", new_path)
+
+    assert fpd.migrate_default_hash_cache() is False
+    assert capsys.readouterr().out == ""
+    assert old_wal.read_text(encoding="utf-8") == "wal"
+    assert not new_path.exists()
+    assert not Path(str(new_path) + "-wal").exists()

--- a/tests/test_location_cache.py
+++ b/tests/test_location_cache.py
@@ -61,7 +61,7 @@ def _patch_exiftool(monkeypatch, responses_by_name):
         def stop(self):
             pass
 
-        def batch_query(self, filepaths):
+        def batch_query(self, filepaths, fast2=False):
             return {
                 fp: responses_by_name.get(Path(fp).name, (None, None, None))
                 for fp in filepaths
@@ -127,6 +127,7 @@ def test_run_scan_reuses_sqlite_location_cache_across_tsvs(tmp_path, monkeypatch
         quiet=True,
         hash_options=hash_options,
         location_options=location_options,
+        min_image_size=0,
     )
     assert calls["count"] == 1
 
@@ -140,6 +141,7 @@ def test_run_scan_reuses_sqlite_location_cache_across_tsvs(tmp_path, monkeypatch
         quiet=True,
         hash_options=hash_options,
         location_options=location_options,
+        min_image_size=0,
     )
     assert calls["count"] == 1
 
@@ -184,6 +186,7 @@ def test_run_scan_uses_tsv_prime_when_location_cache_disabled(
         quiet=True,
         hash_options=fpd.parse_hash_args(hash_mode="off"),
         location_options=fpd.parse_location_args(no_location_cache=True),
+        min_image_size=0,
     )
 
     assert calls["count"] == 0

--- a/tests/test_parallel_scan.py
+++ b/tests/test_parallel_scan.py
@@ -364,14 +364,26 @@ def test_file_counts_include_size_filtered_and_worker_paths(
 def test_geolocate_lock_serializes_nominatim_requests(monkeypatch):
     timestamps = []
     timestamps_lock = threading.Lock()
+    fake_time_lock = threading.Lock()
+    fake_now = {"value": 1_000.0}
     start_event = threading.Event()
     errors = []
 
+    def fake_time():
+        with fake_time_lock:
+            return fake_now["value"]
+
+    def fake_sleep(seconds):
+        with fake_time_lock:
+            fake_now["value"] += seconds
+
     def fake_urlopen(req, timeout):
         with timestamps_lock:
-            timestamps.append(time.monotonic())
+            timestamps.append(fpd.time.time())
         return FakeResponse({"display_name": "Serialized Place"})
 
+    monkeypatch.setattr(fpd.time, "time", fake_time)
+    monkeypatch.setattr(fpd.time, "sleep", fake_sleep)
     monkeypatch.setattr(fpd.urllib.request, "urlopen", fake_urlopen)
 
     def call_geolocate(i):
@@ -528,7 +540,39 @@ def test_crashing_worker_records_failed_batch_with_blank_exif(
     assert any(row["date_taken"] for row in rows)
 
 
-def test_normal_shutdown_timeout_warns_and_returns_quickly(
+def test_missing_exiftool_startup_failure_fails_scan(tmp_path, monkeypatch, capsys):
+    root = tmp_path / "scan"
+    path = root / "a.jpg"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"jpg")
+
+    class MissingExifTool:
+        def start(self):
+            raise FileNotFoundError("exiftool")
+
+        def stop(self):
+            pass
+
+    monkeypatch.setattr(fpd, "ExifToolPersistent", MissingExifTool)
+    output = tmp_path / "out.tsv"
+
+    assert (
+        fpd.run_scan(
+            str(root),
+            str(output),
+            {"jpg"},
+            quiet=True,
+            hash_options=fpd.parse_hash_args(hash_mode="off"),
+            workers=1,
+            min_image_size=0,
+        )
+        is False
+    )
+    assert "failed to start" in capsys.readouterr().err
+    assert not output.exists()
+
+
+def test_normal_shutdown_timeout_fails_and_returns_quickly(
     tmp_path, monkeypatch, capsys
 ):
     monkeypatch.setattr(fpd, "WORKER_SHUTDOWN_TIMEOUT_SECONDS", 0.2)
@@ -542,7 +586,7 @@ def test_normal_shutdown_timeout_warns_and_returns_quickly(
             pass
 
         def stop(self):
-            time.sleep(2)
+            time.sleep(0.6)
 
         def batch_query(self, filepaths, fast2=False):
             return {
@@ -554,14 +598,17 @@ def test_normal_shutdown_timeout_warns_and_returns_quickly(
     output = tmp_path / "out.tsv"
 
     started = time.monotonic()
-    assert fpd.run_scan(
-        str(root),
-        str(output),
-        {"jpg"},
-        quiet=True,
-        hash_options=fpd.parse_hash_args(hash_mode="off"),
-        workers=1,
-        min_image_size=0,
+    assert (
+        fpd.run_scan(
+            str(root),
+            str(output),
+            {"jpg"},
+            quiet=True,
+            hash_options=fpd.parse_hash_args(hash_mode="off"),
+            workers=1,
+            min_image_size=0,
+        )
+        is False
     )
     elapsed = time.monotonic() - started
 

--- a/tests/test_parallel_scan.py
+++ b/tests/test_parallel_scan.py
@@ -71,7 +71,7 @@ def _patch_fixture_exiftool(monkeypatch, responses):
         def stop(self):
             pass
 
-        def batch_query(self, filepaths):
+        def batch_query(self, filepaths, fast2=False):
             return {fp: responses.get(fp, (None, None, None)) for fp in filepaths}
 
     monkeypatch.setattr(fpd, "ExifToolPersistent", FixtureExifTool)
@@ -127,6 +127,7 @@ def test_single_worker_matches_expected_serial_inventory(tmp_path, monkeypatch):
         quiet=True,
         hash_options=hash_options,
         workers=1,
+        min_image_size=0,
     )
 
     assert output.read_bytes() == _expected_inventory_bytes(root, hash_options)
@@ -148,6 +149,7 @@ def test_multi_worker_matches_single_worker_inventory(tmp_path, monkeypatch):
         quiet=True,
         hash_options=hash_options,
         workers=1,
+        min_image_size=0,
     )
     assert fpd.run_scan(
         str(root),
@@ -156,9 +158,207 @@ def test_multi_worker_matches_single_worker_inventory(tmp_path, monkeypatch):
         quiet=True,
         hash_options=hash_options,
         workers=4,
+        min_image_size=0,
     )
 
     assert multi.read_bytes() == single.read_bytes()
+
+
+def _write_sized_file(root, name, size):
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pattern = name.encode("ascii") or b"x"
+    path.write_bytes((pattern * ((size // len(pattern)) + 1))[:size])
+    return path
+
+
+def _read_data_rows(path):
+    with open(path, "r", encoding="utf-8", newline="") as f:
+        return [
+            row
+            for row in csv.DictReader(
+                (line for line in f if not line.startswith("#")),
+                delimiter="\t",
+            )
+        ]
+
+
+def _patch_recording_exiftool(monkeypatch, calls):
+    class RecordingExifTool:
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def batch_query(self, filepaths, fast2=False):
+            calls.append((fast2, tuple(sorted(Path(fp).name for fp in filepaths))))
+            return {
+                fp: ("2024:01:01 10:00:00", "37.871", "-122.273")
+                for fp in filepaths
+            }
+
+    monkeypatch.setattr(fpd, "ExifToolPersistent", RecordingExifTool)
+
+
+def test_min_image_size_filter_routes_tiny_images_only(tmp_path, monkeypatch):
+    root = tmp_path / "scan"
+    _write_sized_file(root, "tiny.jpg", 1_000)
+    _write_sized_file(root, "normal.jpg", 200_000)
+    _write_sized_file(root, "tiny.png", 5_000)
+    _write_sized_file(root, "tiny.nef", 1_000)
+    _write_sized_file(root, "tiny.mp4", 1_000)
+    calls = []
+    _patch_recording_exiftool(monkeypatch, calls)
+    output = tmp_path / "out.tsv"
+
+    assert fpd.run_scan(
+        str(root),
+        str(output),
+        None,
+        quiet=True,
+        hash_options=fpd.parse_hash_args(hash_mode="off"),
+        workers=1,
+        min_image_size=100_000,
+    )
+
+    sent = {name for _fast2, names in calls for name in names}
+    assert "tiny.jpg" not in sent
+    assert "tiny.png" not in sent
+    assert {"normal.jpg", "tiny.nef", "tiny.mp4"} <= sent
+
+    rows = {Path(row["filepath"]).name: row for row in _read_data_rows(output)}
+    assert set(rows) == {"tiny.jpg", "normal.jpg", "tiny.png", "tiny.nef", "tiny.mp4"}
+    assert rows["tiny.jpg"]["size_bytes"] == "1000"
+    assert rows["tiny.png"]["size_bytes"] == "5000"
+    assert rows["tiny.jpg"]["date_taken"] == ""
+    assert rows["tiny.png"]["date_taken"] == ""
+    assert rows["normal.jpg"]["date_taken"] == "2024:01:01 10:00:00"
+    assert rows["tiny.nef"]["date_taken"] == "2024:01:01 10:00:00"
+    assert rows["tiny.mp4"]["date_taken"] == "2024:01:01 10:00:00"
+
+
+def test_min_image_size_zero_disables_filter(tmp_path, monkeypatch):
+    root = tmp_path / "scan"
+    for name, size in [
+        ("tiny.jpg", 1_000),
+        ("normal.jpg", 200_000),
+        ("tiny.png", 5_000),
+        ("tiny.nef", 1_000),
+        ("tiny.mp4", 1_000),
+    ]:
+        _write_sized_file(root, name, size)
+    calls = []
+    _patch_recording_exiftool(monkeypatch, calls)
+
+    assert fpd.run_scan(
+        str(root),
+        str(tmp_path / "out.tsv"),
+        None,
+        quiet=True,
+        hash_options=fpd.parse_hash_args(hash_mode="off"),
+        workers=1,
+        min_image_size=0,
+    )
+
+    sent = {name for _fast2, names in calls for name in names}
+    assert sent == {"tiny.jpg", "normal.jpg", "tiny.png", "tiny.nef", "tiny.mp4"}
+
+
+def test_fast2_applies_only_to_safe_image_extensions(tmp_path, monkeypatch):
+    root = tmp_path / "scan"
+    for name in ["a.jpg", "b.png", "c.nef", "d.mp4"]:
+        _write_sized_file(root, name, 1_000)
+    calls = []
+    _patch_recording_exiftool(monkeypatch, calls)
+
+    assert fpd.run_scan(
+        str(root),
+        str(tmp_path / "out.tsv"),
+        None,
+        quiet=True,
+        hash_options=fpd.parse_hash_args(hash_mode="off"),
+        workers=1,
+        min_image_size=0,
+    )
+
+    assert len(calls) == 2
+    assert (True, ("a.jpg", "b.png")) in calls
+    assert (False, ("c.nef", "d.mp4")) in calls
+
+
+def test_all_jpeg_batch_runs_only_fast2_query(tmp_path, monkeypatch):
+    root = tmp_path / "scan"
+    for name in ["a.jpg", "b.jpeg", "c.jpg"]:
+        _write_sized_file(root, name, 1_000)
+    calls = []
+    _patch_recording_exiftool(monkeypatch, calls)
+
+    assert fpd.run_scan(
+        str(root),
+        str(tmp_path / "out.tsv"),
+        None,
+        quiet=True,
+        hash_options=fpd.parse_hash_args(hash_mode="off"),
+        workers=1,
+        min_image_size=0,
+    )
+
+    assert calls == [(True, ("a.jpg", "b.jpeg", "c.jpg"))]
+
+
+def test_all_raw_batch_runs_only_full_parse_query(tmp_path, monkeypatch):
+    root = tmp_path / "scan"
+    for name in ["a.nef", "b.nef", "c.nef"]:
+        _write_sized_file(root, name, 1_000)
+    calls = []
+    _patch_recording_exiftool(monkeypatch, calls)
+
+    assert fpd.run_scan(
+        str(root),
+        str(tmp_path / "out.tsv"),
+        None,
+        quiet=True,
+        hash_options=fpd.parse_hash_args(hash_mode="off"),
+        workers=1,
+        min_image_size=0,
+    )
+
+    assert calls == [(False, ("a.nef", "b.nef", "c.nef"))]
+
+
+def test_file_counts_include_size_filtered_and_worker_paths(
+    tmp_path, monkeypatch
+):
+    root = tmp_path / "scan"
+    _write_sized_file(root, "tiny-a.jpg", 1_000)
+    _write_sized_file(root, "tiny-b.jpg", 1_000)
+    _write_sized_file(root, "normal.jpg", 200_000)
+    _write_sized_file(root, "a.txt", 100)
+    _write_sized_file(root, "b.txt", 100)
+    calls = []
+    captured_counts = {}
+    _patch_recording_exiftool(monkeypatch, calls)
+
+    def capture_summary(photo_data, file_counts, quiet, debug=False):
+        captured_counts.update(file_counts)
+
+    monkeypatch.setattr(fpd, "summarize_results", capture_summary)
+
+    assert fpd.run_scan(
+        str(root),
+        str(tmp_path / "out.tsv"),
+        None,
+        quiet=True,
+        hash_options=fpd.parse_hash_args(hash_mode="off"),
+        workers=1,
+        min_image_size=100_000,
+    )
+
+    assert captured_counts["jpg"] == 3
+    assert captured_counts["txt"] == 2
+    sent = {name for _fast2, names in calls for name in names}
+    assert sent == {"normal.jpg"}
 
 
 def test_geolocate_lock_serializes_nominatim_requests(monkeypatch):
@@ -241,7 +441,7 @@ def test_keyboard_interrupt_during_dispatch_writes_clean_partial_tsv(
         def stop(self):
             pass
 
-        def batch_query(self, filepaths):
+        def batch_query(self, filepaths, fast2=False):
             time.sleep(0.1)
             return {
                 fp: ("2024:01:01 10:00:00", "37.871", "-122.273")
@@ -260,6 +460,7 @@ def test_keyboard_interrupt_during_dispatch_writes_clean_partial_tsv(
             quiet=True,
             hash_options=fpd.parse_hash_args(hash_mode="off"),
             workers=2,
+            min_image_size=0,
         )
     finally:
         timer.cancel()
@@ -289,7 +490,7 @@ def test_crashing_worker_records_failed_batch_with_blank_exif(
         def stop(self):
             pass
 
-        def batch_query(self, filepaths):
+        def batch_query(self, filepaths, fast2=False):
             with self.lock:
                 type(self).calls += 1
                 call = type(self).calls
@@ -310,6 +511,7 @@ def test_crashing_worker_records_failed_batch_with_blank_exif(
         quiet=True,
         hash_options=fpd.parse_hash_args(hash_mode="off"),
         workers=1,
+        min_image_size=0,
     )
 
     with open(output, "r", encoding="utf-8", newline="") as f:
@@ -342,7 +544,7 @@ def test_normal_shutdown_timeout_warns_and_returns_quickly(
         def stop(self):
             time.sleep(2)
 
-        def batch_query(self, filepaths):
+        def batch_query(self, filepaths, fast2=False):
             return {
                 fp: ("2024:01:01 10:00:00", "37.871", "-122.273")
                 for fp in filepaths
@@ -359,6 +561,7 @@ def test_normal_shutdown_timeout_warns_and_returns_quickly(
         quiet=True,
         hash_options=fpd.parse_hash_args(hash_mode="off"),
         workers=1,
+        min_image_size=0,
     )
     elapsed = time.monotonic() - started
 

--- a/tests/test_parallel_scan.py
+++ b/tests/test_parallel_scan.py
@@ -1,0 +1,413 @@
+import csv
+import io
+import os
+import signal
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+import findphotodates as fpd
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self):
+        import json
+
+        return json.dumps(self.payload).encode("utf-8")
+
+
+@pytest.fixture(autouse=True)
+def reset_geolocation_state():
+    saved_cache = dict(fpd._coord_cache)
+    saved_time = fpd._last_geolocate_time
+    fpd._coord_cache.clear()
+    fpd._last_geolocate_time = 0
+    yield
+    fpd._coord_cache.clear()
+    fpd._coord_cache.update(saved_cache)
+    fpd._last_geolocate_time = saved_time
+
+
+def _make_fixture_tree(root):
+    files = {
+        "a.jpg": b"jpg-a",
+        "b.png": b"png-b",
+        "c.mp4": b"mp4-c",
+        "d.txt": b"text-d",
+        "sub/e.jpg": b"jpg-e",
+    }
+    for rel, data in files.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+    return files
+
+
+def _responses_for_fixture(root):
+    return {
+        str(root / "a.jpg"): ("2024:01:01 10:00:00", "37.871", "-122.273"),
+        str(root / "b.png"): ("2024:01:02 10:00:00", "37.872", "-122.274"),
+        str(root / "c.mp4"): ("2024:01:03 10:00:00", "", ""),
+        str(root / "sub/e.jpg"): ("2024:01:04 10:00:00", "37.873", "-122.275"),
+    }
+
+
+def _patch_fixture_exiftool(monkeypatch, responses):
+    class FixtureExifTool:
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def batch_query(self, filepaths):
+            return {fp: responses.get(fp, (None, None, None)) for fp in filepaths}
+
+    monkeypatch.setattr(fpd, "ExifToolPersistent", FixtureExifTool)
+
+
+def _expected_inventory_bytes(root, hash_options):
+    rows = []
+    responses = _responses_for_fixture(root)
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        filepath = str(path)
+        stat_info = path.stat()
+        if path.suffix.lower().lstrip(".") in fpd.EXIFTOOL_EXTENSIONS:
+            date_taken, gps_lat, gps_lon = responses.get(filepath, ("", "", ""))
+        else:
+            date_taken, gps_lat, gps_lon = "", "", ""
+        rows.append(
+            [
+                filepath,
+                date_taken or "",
+                str(stat_info.st_size),
+                str(stat_info.st_mtime_ns),
+                gps_lat or "",
+                gps_lon or "",
+                "",
+                "",
+            ]
+        )
+
+    out = io.StringIO()
+    out.write(f"# inventory_root={root}\n")
+    out.write(f"# hash_mode={hash_options.hash_mode}\n")
+    out.write(fpd.TSV_HEADER + "\n")
+    writer = csv.writer(out, delimiter="\t", quoting=csv.QUOTE_MINIMAL)
+    writer.writerow(fpd.TSV_COLUMNS)
+    writer.writerows(rows)
+    return out.getvalue().encode("utf-8")
+
+
+def test_single_worker_matches_expected_serial_inventory(tmp_path, monkeypatch):
+    root = tmp_path / "scan"
+    _make_fixture_tree(root)
+    responses = _responses_for_fixture(root)
+    _patch_fixture_exiftool(monkeypatch, responses)
+    output = tmp_path / "single.tsv"
+    hash_options = fpd.parse_hash_args(hash_mode="off")
+
+    assert fpd.run_scan(
+        str(root),
+        str(output),
+        None,
+        quiet=True,
+        hash_options=hash_options,
+        workers=1,
+    )
+
+    assert output.read_bytes() == _expected_inventory_bytes(root, hash_options)
+
+
+def test_multi_worker_matches_single_worker_inventory(tmp_path, monkeypatch):
+    root = tmp_path / "scan"
+    _make_fixture_tree(root)
+    responses = _responses_for_fixture(root)
+    _patch_fixture_exiftool(monkeypatch, responses)
+    hash_options = fpd.parse_hash_args(hash_mode="off")
+    single = tmp_path / "single.tsv"
+    multi = tmp_path / "multi.tsv"
+
+    assert fpd.run_scan(
+        str(root),
+        str(single),
+        None,
+        quiet=True,
+        hash_options=hash_options,
+        workers=1,
+    )
+    assert fpd.run_scan(
+        str(root),
+        str(multi),
+        None,
+        quiet=True,
+        hash_options=hash_options,
+        workers=4,
+    )
+
+    assert multi.read_bytes() == single.read_bytes()
+
+
+def test_geolocate_lock_serializes_nominatim_requests(monkeypatch):
+    timestamps = []
+    timestamps_lock = threading.Lock()
+    start_event = threading.Event()
+    errors = []
+
+    def fake_urlopen(req, timeout):
+        with timestamps_lock:
+            timestamps.append(time.monotonic())
+        return FakeResponse({"display_name": "Serialized Place"})
+
+    monkeypatch.setattr(fpd.urllib.request, "urlopen", fake_urlopen)
+
+    def call_geolocate(i):
+        try:
+            start_event.wait()
+            fpd.geolocate(f"{10 + i * 0.02:.4f}", f"{20 + i * 0.02:.4f}")
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=call_geolocate, args=(i,)) for i in range(20)]
+    for thread in threads:
+        thread.start()
+    start_event.set()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    assert len(timestamps) == 20
+    intervals = [b - a for a, b in zip(timestamps, timestamps[1:], strict=False)]
+    assert all(interval >= 0.99 for interval in intervals)
+
+
+def test_location_cache_concurrent_writes(tmp_path):
+    conn = fpd.open_location_cache(str(tmp_path / "location_cache.sqlite"))
+    errors = []
+
+    def write_rows(worker_id):
+        try:
+            for i in range(100):
+                fpd.put_cached_location(
+                    conn,
+                    float(worker_id),
+                    float(i),
+                    fpd.LOCATION_CACHE_PRECISION,
+                    f"location-{worker_id}-{i}",
+                )
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=write_rows, args=(i,)) for i in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    with fpd._sqlite_lock:
+        count = conn.execute("SELECT COUNT(*) FROM location_cache").fetchone()[0]
+    conn.close()
+    assert count == 400
+
+
+def test_keyboard_interrupt_during_dispatch_writes_clean_partial_tsv(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(fpd, "EXIFTOOL_BATCH_SIZE", 5)
+    root = tmp_path / "scan"
+    for i in range(30):
+        path = root / f"{i:03d}.jpg"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"jpg")
+
+    class SlowExifTool:
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def batch_query(self, filepaths):
+            time.sleep(0.1)
+            return {
+                fp: ("2024:01:01 10:00:00", "37.871", "-122.273")
+                for fp in filepaths
+            }
+
+    monkeypatch.setattr(fpd, "ExifToolPersistent", SlowExifTool)
+    output = tmp_path / "partial.tsv"
+    timer = threading.Timer(0.16, lambda: os.kill(os.getpid(), signal.SIGINT))
+    timer.start()
+    try:
+        result = fpd.run_scan(
+            str(root),
+            str(output),
+            {"jpg"},
+            quiet=True,
+            hash_options=fpd.parse_hash_args(hash_mode="off"),
+            workers=2,
+        )
+    finally:
+        timer.cancel()
+
+    assert result is False
+    cache = fpd.load_cache(str(output))
+    assert 0 <= len(cache) < 30
+
+
+def test_crashing_worker_records_failed_batch_with_blank_exif(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(fpd, "EXIFTOOL_BATCH_SIZE", 2)
+    root = tmp_path / "scan"
+    for i in range(6):
+        path = root / f"{i:03d}.jpg"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"jpg")
+
+    class FlakyExifTool:
+        calls = 0
+        lock = threading.Lock()
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def batch_query(self, filepaths):
+            with self.lock:
+                type(self).calls += 1
+                call = type(self).calls
+            if call == 1:
+                raise RuntimeError("boom")
+            return {
+                fp: ("2024:01:01 10:00:00", "37.871", "-122.273")
+                for fp in filepaths
+            }
+
+    monkeypatch.setattr(fpd, "ExifToolPersistent", FlakyExifTool)
+    output = tmp_path / "out.tsv"
+
+    assert fpd.run_scan(
+        str(root),
+        str(output),
+        {"jpg"},
+        quiet=True,
+        hash_options=fpd.parse_hash_args(hash_mode="off"),
+        workers=1,
+    )
+
+    with open(output, "r", encoding="utf-8", newline="") as f:
+        rows = [
+            row
+            for row in csv.DictReader(
+                (line for line in f if not line.startswith("#")),
+                delimiter="\t",
+            )
+        ]
+    assert len(rows) == 6
+    assert FlakyExifTool.calls == 3
+    assert any(not row["date_taken"] for row in rows)
+    assert any(row["date_taken"] for row in rows)
+
+
+def test_normal_shutdown_timeout_warns_and_returns_quickly(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setattr(fpd, "WORKER_SHUTDOWN_TIMEOUT_SECONDS", 0.2)
+    root = tmp_path / "scan"
+    path = root / "a.jpg"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"jpg")
+
+    class HangingStopExifTool:
+        def start(self):
+            pass
+
+        def stop(self):
+            time.sleep(2)
+
+        def batch_query(self, filepaths):
+            return {
+                fp: ("2024:01:01 10:00:00", "37.871", "-122.273")
+                for fp in filepaths
+            }
+
+    monkeypatch.setattr(fpd, "ExifToolPersistent", HangingStopExifTool)
+    output = tmp_path / "out.tsv"
+
+    started = time.monotonic()
+    assert fpd.run_scan(
+        str(root),
+        str(output),
+        {"jpg"},
+        quiet=True,
+        hash_options=fpd.parse_hash_args(hash_mode="off"),
+        workers=1,
+    )
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 1.0
+    assert "did not exit within 0.2 seconds; abandoning" in capsys.readouterr().err
+
+
+def test_perf_summary_marks_parallel_sums_and_worker_active(capsys):
+    assert fpd.WORKER_SHUTDOWN_TIMEOUT_SECONDS == 60
+    fpd._print_perf_summary(
+        "fixture",
+        {
+            "wall_total": 10,
+            "worker_count": 4,
+            "t_exiftool": 30,
+            "t_hashing": 5,
+            "t_geolocate": 2,
+            "worker_details": [
+                {
+                    "worker_id": 1,
+                    "wall": 10,
+                    "t_active": 7,
+                    "t_exiftool": 6,
+                    "t_hashing": 1,
+                    "t_geolocate": 0,
+                    "t_queue_push": 0.1,
+                    "files": 3,
+                    "errors": 0,
+                },
+                {
+                    "worker_id": 2,
+                    "wall": 9,
+                    "t_active": 6,
+                    "t_exiftool": 5,
+                    "t_hashing": 1,
+                    "t_geolocate": 0,
+                    "t_queue_push": 0.1,
+                    "files": 2,
+                    "errors": 1,
+                },
+            ],
+        },
+    )
+
+    out = capsys.readouterr().out
+    assert "ExifTool (4w sum)" in out
+    assert "Content hashing (4w sum)" in out
+    assert "Geolocation (4w sum)" in out
+    assert out.count("(sum across workers)") == 3
+    assert "Worker active total" in out
+    assert "Worker total" not in out
+    assert "active=7.00s" in out

--- a/tests/test_reparse_skip.py
+++ b/tests/test_reparse_skip.py
@@ -1,0 +1,65 @@
+"""Tests for Windows reparse-point directory skipping in find_files().
+
+We can't create real NTFS junctions in the test environment, so we exercise
+_is_windows_reparse_point_dir() with fake DirEntry objects whose stat() returns
+an object carrying st_file_attributes — mirroring what os.scandir() returns on
+Windows.  We also verify find_files() still indexes ordinary files on POSIX.
+"""
+
+import os
+import stat as stat_mod
+import tempfile
+
+import findphotodates
+
+
+REPARSE_BIT = getattr(stat_mod, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+DIRECTORY_BIT = 0x10
+
+
+class _FakeStat:
+    def __init__(self, attrs):
+        self.st_file_attributes = attrs
+
+
+class _FakeEntry:
+    def __init__(self, path, attrs):
+        self.path = path
+        self.name = os.path.basename(path)
+        self._attrs = attrs
+
+    def stat(self, follow_symlinks=True):
+        return _FakeStat(self._attrs)
+
+
+def test_reparse_dir_helper_true_when_bit_set():
+    entry = _FakeEntry(
+        "C:\\ProgramData\\Application Data", REPARSE_BIT | DIRECTORY_BIT
+    )
+    assert findphotodates._is_windows_reparse_point_dir(entry) is True
+
+
+def test_reparse_dir_helper_false_when_bit_clear():
+    entry = _FakeEntry("C:\\ProgramData\\Adobe", DIRECTORY_BIT)
+    assert findphotodates._is_windows_reparse_point_dir(entry) is False
+
+
+def test_reparse_dir_helper_false_when_attribute_missing():
+    # Simulate a POSIX scandir entry — stat() result has no st_file_attributes.
+    class _PosixEntry:
+        path = "/tmp/foo"
+
+        def stat(self, follow_symlinks=True):
+            return os.stat_result((0,) * 10)
+
+    assert findphotodates._is_windows_reparse_point_dir(_PosixEntry()) is False
+
+
+def test_find_files_indexes_normal_files_on_posix():
+    # Sanity check on this platform: ordinary files are still yielded.
+    with tempfile.TemporaryDirectory() as d:
+        p = os.path.join(d, "hello.txt")
+        with open(p, "w") as f:
+            f.write("hi")
+        results = list(findphotodates.find_files(d, None))
+        assert any(r[0] == p for r in results)


### PR DESCRIPTION
Run exiftool with -fast2 for performance, only run exiftool on photos over 100k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parallel scanning with configurable worker threads for faster processing
  * Geolocation caching to reduce API calls
  * Configurable minimum image size filter to skip tiny images
  * Automatic Windows cache migration on startup
  * Improved terminal output capability detection

* **Bug Fixes**
  * Resolved Windows junction directory infinite loop issue
  * Fixed ANSI color codes to display only in terminal output
  * Enhanced Unicode handling in metadata extraction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->